### PR TITLE
build(ci): add dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
   build:
     name: Build and push
     runs-on: ubuntu-18.04
+    needs: [gatekeep]
     steps:
       - uses: actions/checkout@v2
       - name: Extract branch name


### PR DESCRIPTION
## Problem

The step to push an image to ECR never runs

## Solution

Line 96 is never consistently true since the jobs run in parallel. 
```
      - name: Push to ECR
        if: needs.gatekeep.outputs.proceed == 'true'
```
This solution ensures that the gatekeep job is run before the build job. 
