### PR TITLE
fix: replace deprecated bodyparser

### DIFF
--- a/backend/src/bootstrap/index.ts
+++ b/backend/src/bootstrap/index.ts
@@ -1,6 +1,5 @@
 import express, { Express } from 'express'
 import session from 'express-session'
-import bodyParser from 'body-parser'
 import { Sequelize, SequelizeOptions } from 'sequelize-typescript'
 import SequelizeStoreFactory from 'connect-session-sequelize'
 
@@ -83,7 +82,7 @@ export async function bootstrap(): Promise<{
     app.set('trust proxy', 1)
   }
 
-  const apiMiddleware = [sessionMiddleware, bodyParser.json()]
+  const apiMiddleware = [sessionMiddleware, express.json()]
   app.use('/api/v1', apiMiddleware, api({ auth }))
 
   console.log('Connecting to Sequelize')


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

bodyparser has been deprecated.

## Solution

Replace with `express.json()` 

_How did you solve the problem?_

Use built in bodyparser in express 4+

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
[insert screenshot here]

**AFTER**:
[insert screenshot here]

## Tests

_What tests should be run to confirm functionality?_

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
