### PR TITLE
More specific configuration for creating VPCs

### DIFF
--- a/guides/deploying/AWS.md
+++ b/guides/deploying/AWS.md
@@ -15,6 +15,8 @@ VPC, segmented into three subnets, gated by NAT Gateways and Security Groups
 
 - [ ] Navigate to the VPC section in AWS Console
 - [ ] Create a VPC named `<app-name>-<environment>`, eg `checkfirst-staging`
+  - [ ] for IPv4, use the AWS default (in the placeholder) - `10.0.0.0/24`
+  - [ ] for IPv6, select 'Amazon-provided IPv6 CIDR block'
 
 ### Subnets
 


### PR DESCRIPTION
## Problem

VPC creation section could do with more details.

## Solution

I asked Pallani for a second opinion and he said it was okay to use the AWS defaults. Think we can go with that for ease of learning/consistency (when in doubt, just use AWS defaults).

But if you think we should use `172.31.0.0/16` instead, I'll make the change. Thanks!
