### PR TITLE
feat(codeowner): Add file .github/CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# For syntax visit https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
+
+# Set one primary team as default onwer for the whole repository
+
+* @opengovsg/team-name
+
+# List overrides for parts of the repo below (if necessary)


### PR DESCRIPTION
## Context

All repositories should have a primary owner (typically a team). This should be documented in the file `.github/CODEOWNER` (see doc [here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file))

## Approach

Add basic CODEOWNER file to repo


cc @LoneRifle @liangyuanruo 