### PR TITLE
feat: implements healthcheck endpoint

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 if [ -z "$husky_skip_init" ]; then
   debug () {
-    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+    if [ "$HUSKY_DEBUG" = "1" ]; then
+      echo "husky (debug) - $1"
+    fi
   }
 
   readonly hook_name="$(basename "$0")"

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 if [ -z "$husky_skip_init" ]; then
   debug () {
-    if [ "$HUSKY_DEBUG" = "1" ]; then
-      echo "husky (debug) - $1"
-    fi
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
   }
 
   readonly hook_name="$(basename "$0")"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1387,6 +1387,14 @@
         "uuid": "8.3.2"
       }
     },
+    "@nestjs/terminus": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-8.0.0.tgz",
+      "integrity": "sha512-H+bj7wHVLMxxLP6bKj8pcdMcUqhGiQONYACpLQdYK9Cl49ReNkKEg1XahTnqXCBkPUgEcOMIpEpuVvJ0eVnpFA==",
+      "requires": {
+        "check-disk-space": "3.0.1"
+      }
+    },
     "@nestjs/testing": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-8.0.6.tgz",
@@ -2952,6 +2960,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "check-disk-space": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.0.1.tgz",
+      "integrity": "sha512-wRG5ZihEZUXAKVCio5YkLgrHsHDrD+GjRBjxJvoJvN9wrze7EdvYGnOYJSsCyZ4b40jBa3lDmWDmESY9QDQGcg=="
     },
     "chokidar": {
       "version": "3.5.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "@nestjs/core": "^8.0.6",
     "@nestjs/platform-express": "^8.0.6",
     "@nestjs/sequelize": "^8.0.0",
+    "@nestjs/terminus": "^8.0.0",
     "convict": "^6.2.0",
     "express-session": "^1.17.2",
     "helmet": "^4.6.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,6 +4,8 @@ import { HelmetMiddleware } from 'middlewares/helmet.middleware'
 import { SessionMiddleware } from 'middlewares/session.middleware'
 import { ConfigModule } from 'config/config.module'
 import { AuthModule } from 'auth/auth.module'
+import { TerminusModule } from '@nestjs/terminus'
+import { HealthModule } from './health/health.module'
 
 @Module({
   imports: [
@@ -14,6 +16,8 @@ import { AuthModule } from 'auth/auth.module'
       synchronize: true, // TO-DO: remove in production
     }),
     AuthModule,
+    TerminusModule,
+    HealthModule,
   ],
 })
 export class AppModule implements NestModule {

--- a/backend/src/config/config.schema.ts
+++ b/backend/src/config/config.schema.ts
@@ -59,15 +59,17 @@ export const schema: Schema<ConfigSchema> = {
   },
   health: {
     heapSizeThreshold: {
-      doc: 'Heap size treshold before healthcheck fails (in bytes).',
+      doc: 'Heap size threshold before healthcheck fails (in bytes).',
       env: 'HEAP_SIZE_THRESHOLD',
       format: 'int',
+      // TODO: Set to a more reasonable value depending on the instance size used.
       default: 200 * 1024 * 1024, // 200MB
     },
     rssThreshold: {
-      doc: 'Heap size treshold before healthcheck fails (in bytes).',
+      doc: 'Resident set size threshold before healthcheck fails (in bytes).',
       env: 'RSS_THRESHOLD',
       format: 'int',
+      // TODO: Set to a more reasonable value depending on the instance size used.
       default: 3000 * 1024 * 1024, // 3000MB
     },
   },

--- a/backend/src/config/config.schema.ts
+++ b/backend/src/config/config.schema.ts
@@ -5,6 +5,7 @@ export interface ConfigSchema {
   environment: 'development' | 'staging' | 'production' | 'test'
   session: { name: string; secret: string; cookie: { maxAge: number } }
   otp: { expiry: number; secret: string }
+  health: { heapSizeThreshold: number; rssThreshold: number }
 }
 
 export const schema: Schema<ConfigSchema> = {
@@ -54,6 +55,20 @@ export const schema: Schema<ConfigSchema> = {
       env: 'OTP_SECRET',
       format: '*',
       default: 'toomanysecrets',
+    },
+  },
+  health: {
+    heapSizeThreshold: {
+      doc: 'Heap size treshold before healthcheck fails (in bytes).',
+      env: 'HEAP_SIZE_THRESHOLD',
+      format: 'int',
+      default: 200 * 1024 * 1024, // 200MB
+    },
+    rssThreshold: {
+      doc: 'Heap size treshold before healthcheck fails (in bytes).',
+      env: 'RSS_THRESHOLD',
+      format: 'int',
+      default: 3000 * 1024 * 1024, // 3000MB
     },
   },
 }

--- a/backend/src/health/health.controller.spec.ts
+++ b/backend/src/health/health.controller.spec.ts
@@ -1,6 +1,6 @@
 import { TerminusModule } from '@nestjs/terminus'
 import { Test, TestingModule } from '@nestjs/testing'
-import { ConfigModule } from 'config/config.module'
+import { ConfigModule } from '../config/config.module'
 import { HealthController } from './health.controller'
 
 describe('HealthController', () => {

--- a/backend/src/health/health.controller.spec.ts
+++ b/backend/src/health/health.controller.spec.ts
@@ -1,0 +1,21 @@
+import { TerminusModule } from '@nestjs/terminus'
+import { Test, TestingModule } from '@nestjs/testing'
+import { ConfigModule } from 'config/config.module'
+import { HealthController } from './health.controller'
+
+describe('HealthController', () => {
+  let controller: HealthController
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule, TerminusModule],
+      controllers: [HealthController],
+    }).compile()
+
+    controller = module.get<HealthController>(HealthController)
+  })
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined()
+  })
+})

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -6,7 +6,7 @@ import {
   SequelizeHealthIndicator,
   MemoryHealthIndicator,
 } from '@nestjs/terminus'
-import { ConfigService } from 'config/config.service'
+import { ConfigService } from '../config/config.service'
 
 @Controller('health')
 export class HealthController {

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Get } from '@nestjs/common'
+import {
+  HealthCheck,
+  HealthCheckResult,
+  HealthCheckService,
+  SequelizeHealthIndicator,
+  MemoryHealthIndicator,
+} from '@nestjs/terminus'
+import { ConfigService } from 'config/config.service'
+
+@Controller('health')
+export class HealthController {
+  constructor(
+    private health: HealthCheckService,
+    private config: ConfigService,
+    // Refer to https://github.com/nestjs/terminus/blob/master/sample/ for
+    // examples of how to add other services/databases to healthcheck.
+    private db: SequelizeHealthIndicator,
+    private memory: MemoryHealthIndicator
+  ) {}
+
+  @Get()
+  @HealthCheck()
+  async check(): Promise<HealthCheckResult> {
+    return this.health.check([
+      async () => this.db.pingCheck('database'),
+      async () =>
+        this.memory.checkHeap(
+          'memory_heap',
+          this.config.get('health.heapSizeThreshold')
+        ),
+      async () =>
+        this.memory.checkRSS(
+          'memory_rss',
+          this.config.get('health.rssThreshold')
+        ),
+    ])
+  }
+}

--- a/backend/src/health/health.module.ts
+++ b/backend/src/health/health.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+import { TerminusModule } from '@nestjs/terminus'
+import { HealthController } from './health.controller'
+
+@Module({
+  imports: [SequelizeModule, TerminusModule],
+  controllers: [HealthController],
+})
+export class HealthModule {}


### PR DESCRIPTION
## Context

This pull request implemented the healthcheck endpoint as part of the standard flows on ts-template. The health check endpoint checks that the memory usage does not cross a configurable threshold and the connectivity to any external services (db). 

## Approach

The healthcheck endpoint makes use of the `@nestjs/terminus` module. It uses built in memory checks and sequelize db ping checks.

**Features**:

- Endpoint `/api/health` that returns the status of services. The expected response when services are up is as follows: 
```
{
  "status": "ok",
  "info": {
    "database": {
      "status": "up"
    },
    "memory_heap": {
      "status": "up"
    },
    "memory_rss": {
      "status": "up"
    }
  },
  "error": {},
  "details": {
    "database": {
      "status": "up"
    },
    "memory_heap": {
      "status": "up"
    },
    "memory_rss": {
      "status": "up"
    }
  }
}
```


## Deploy Notes

**New environment variables**:

- `HEAP_SIZE_THRESHOLD` : optional env var for the max memory heap size for the application before the healthcheck endpoint reports a failure
- `RSS_THRESHOLD` : optional env var for the max RSS size for the application before the healthcheck endpoint reports a failure

**New dependencies**:

- `@nestjs/terminus` : NestJS healthcheck module