### PR TITLE
add environmental variables and set up secret detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
       - run: npx lockfile-lint --type npm --path backend/package-lock.json --validate-https --allowed-hosts npm
       - run: npm run lint
       - run: npm run on-backend -- build
+      - name: detect secrets in repo
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.x"
+      - run: pip install detect-secrets==1.2.0
+      - run: npm run detect-secrets:check # pragma: allowlist secret
   test:
     name: Test
     runs-on: ubuntu-18.04

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 if [ -z "$husky_skip_init" ]; then
   debug () {
-    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+    if [ "$HUSKY_DEBUG" = "1" ]; then
+      echo "husky (debug) - $1"
+    fi
   }
 
   readonly hook_name="$(basename "$0")"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run on-backend -- pre-commit && npm run on-frontend -- pre-commit
+npm run pre-commit && npm run on-backend -- pre-commit && npm run on-frontend -- pre-commit

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -73,6 +73,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -111,9 +115,9 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 48
       }
     ]
   },
-  "generated_at": "2022-05-31T02:15:54Z"
+  "generated_at": "2022-06-06T09:34:06Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,119 @@
+{
+  "version": "1.2.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    ".github/workflows/ci.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 42
+      }
+    ]
+  },
+  "generated_at": "2022-05-31T02:15:54Z"
+}

--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ uses the remote branch as the lower bound in the commit range to inspect,
 and there would be no remote branch. Bypass this the first time with
 `git push --no-verify`.
 
+## Secrets Detection
+
+This project makes of [detect-secrets](https://github.com/Yelp/detect-secrets) to prevent secrets and credentials from being committed to the repository. It runs as a pre-commit hook and it needs to be installed (runs as part of `npm run prepare`) if you intend to make commits to the repo.
+
+**Note**: The reason we're running `detect-secrets` through `detect-secrets:precommit` instead of using `lint-staged` is because `detect-secrets-hook` doesn't work well with the combination of output of staged files by `lint-staged` and baseline supplied.
+
+Upon blockage by `detect-secrets-hook`, please take these steps:
+
+- Go into each of the locations pointed out by `detect-secrets-hook` and remove accidentally added secrets
+- If some of these detections are false positive (please be super sure about this, when not sure check with teammates), update the secrets baseline by running `npm run detect-secrets:updateUpon blockage by `detect-secrets-hook`, please take these steps:
+
+- Go into each of the locations pointed out by `detect-secrets-hook` and remove accidentally added secrets
+- If some of these detections are false positive (please be super sure about this, when not sure check with teammates), update the secrets baseline by running `npm run detect-secrets:update
+
 ## Continuous Integration
 Travis is commonly used in OGP. A `.travis.yml` config has been provided
 for convenience, which will run the following in order:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Structure within frontend/backend folder taken from \[1\]. Notably,
 we distinguish between `lib/` and `src/` directories, the latter for
 files that we have to process (eg, transpile) into `build/` or `dist/`. 
 
+## Environmental Variables
+
+For `npm run dev` to work, go to `backend/`, copy the `.env.example` file and past as a `.env` file.
+
 ## Linting
 Done with ESLint, using the following rule configs:
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "on-frontend": "npm run --prefix frontend",
     "postinstall": "npm --prefix backend install && npm --prefix frontend install",
     "dev-docker": "docker-compose up --build",
-    "dev": "env-cmd concurrently \"npm run on-backend -- start:dev\" \"npm run on-frontend -- start\"",
+    "dev": "env-cmd -f backend/.env concurrently \"npm run on-backend -- start:dev\" \"npm run on-frontend -- start\"",
     "lint": "npm run on-backend -- lint && npm run on-frontend -- lint",
     "lint:fix": "npm run on-backend -- lint:fix && npm run on-frontend -- lint:fix",
     "test": "npm run on-backend -- test && npm run on-frontend -- test",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "coverage": "npm run on-backend -- test:cov && cat backend/coverage/lcov.info > lcov.info",
     "cz": "git-cz",
     "start": "node backend/build/index.js",
-    "prepare": "husky install"
+    "pre-commit": "npm run detect-secrets:precommit",
+    "prepare": "husky install && pip install detect-secrets==1.2.0",
+    "detect-secrets:update": "detect-secrets scan --baseline .secrets.baseline",
+    "detect-secrets:check": "git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline",
+    "detect-secrets:precommit": "git diff --staged --name-only -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline"
   },
   "author": "Open Government Products, GovTech Singapore (https://open.gov.sg)",
   "license": "MIT",


### PR DESCRIPTION
First commit closes https://github.com/opengovsg/ts-template/issues/1261. 
- Issue: currently `npm run dev` is not working because `env-cmd` is expecting an env file in the root directory
- Solution: It adds an `.env.example` file to the backend, updates the README to tell the user to duplicate a `.env` file. After doing so, `npm run dev` will work properly. 

Second commit is based on Postman's PR https://github.com/opengovsg/postmangovsg/pull/1554, which was made after we our previous secret detection linter failed to pick up secret. We experimented with a few options and `detect-secrets` work the best.
- Issue: currently, ts-template does not have secret detection
- Solution: add `detect-secrets` 

Not sure if I've set up the `ci.yml` and husky hooks properly — would be good to have someone look through them!