### PR TITLE
build(deps-dev): use wildcard for @types/node

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -39,7 +39,7 @@
         "@types/express-session": "^1.17.5",
         "@types/helmet": "^4.0.0",
         "@types/jest": "^28.1.6",
-        "@types/node": "^16.11.6",
+        "@types/node": "*",
         "@types/nodemailer": "^6.4.4",
         "@types/sequelize": "^4.28.14",
         "@types/supertest": "^2.0.12",

--- a/backend/package.json
+++ b/backend/package.json
@@ -53,7 +53,7 @@
     "@types/express-session": "^1.17.5",
     "@types/helmet": "^4.0.0",
     "@types/jest": "^28.1.6",
-    "@types/node": "^16.11.6",
+    "@types/node": "*",
     "@types/nodemailer": "^6.4.4",
     "@types/sequelize": "^4.28.14",
     "@types/supertest": "^2.0.12",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,7 +35,7 @@
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^14.3.0",
         "@types/jest": "^28.1.6",
-        "@types/node": "^16.11.6",
+        "@types/node": "*",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
         "@types/react-router-dom": "^5.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.3.0",
     "@types/jest": "^28.1.6",
-    "@types/node": "^16.11.6",
+    "@types/node": "*",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
     "@types/react-router-dom": "^5.3.3",


### PR DESCRIPTION
## Context

Use a wildcard for `@types/node`, since that is often tied to node runtime anyway.