### PR TITLE
chore: use github oidc for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Cache Node.js modules
         uses: actions/cache@v3
         with:
@@ -54,7 +54,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Cache Node.js modules
         uses: actions/cache@v3
         with:
@@ -126,11 +126,16 @@ jobs:
           BRANCH: ${{ steps.extract_branch.outputs.branch }}
           SHA: ${{ github.sha }}
       - run: docker build -t ${{ steps.extract_tag.outputs.tag }} -f Dockerfile .
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
       - name: Push to ECR
         if: needs.gatekeep.outputs.proceed == 'true'
         uses: opengovsg/gh-ecr-push@v1
         with:
-          access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           region: ap-southeast-1
           local-image: ${{ steps.extract_tag.outputs.tag }}
@@ -172,11 +177,16 @@ jobs:
             echo EB_ENV=${{ secrets.EB_ENV_PRODUCTION }} >> $GITHUB_ENV;
           fi
         id: select_eb_vars
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
       - name: Deploy to EB
         uses: opengovsg/beanstalk-deploy@v11
         with:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_access_key: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           application_name: ${{ env.EB_APP }}
           environment_name: ${{ env.EB_ENV }}
           version_label: ${{ steps.get_label.outputs.label }}

--- a/docs/deploying/For-Engineers.md
+++ b/docs/deploying/For-Engineers.md
@@ -125,7 +125,7 @@ Resources:
                   - s3:ListBucket
                   - s3:PutObject
                   - s3:ListObjectsV2
-                Resource: arn:aws:s3:::admin.form.gov.sg/*
+                Resource: arn:aws:s3:::<s3-bucket-name>/*
 ​
   GithubOidc:
     Type: AWS::IAM::OIDCProvider

--- a/docs/deploying/For-Engineers.md
+++ b/docs/deploying/For-Engineers.md
@@ -1,30 +1,34 @@
 # Deploying Your Application - An Engineer's Guide
 
-Learn how to prepare your application to take it from your development 
+Learn how to prepare your application to take it from your development
 environment into a deployment ready to receive users.
 
 ## Sign up for Accounts
 
 Register for the following services:
 
-| Name | Purpose |
-|-|-|
-| Cloudflare | CDN, DNS |
-| AWS | Cloud infrastructure |
-| GovTech, Vodien et al | Domain name registrar |
-| Datadog | Logging and monitoring |
-| BetterUptime | Uptime monitoring |
-| Google Groups | Contact email for the application |
-| Zendesk | Product Operations |
+| Name                  | Purpose                           |
+| --------------------- | --------------------------------- |
+| Cloudflare            | CDN, DNS                          |
+| AWS                   | Cloud infrastructure              |
+| GovTech, Vodien et al | Domain name registrar             |
+| Datadog               | Logging and monitoring            |
+| BetterUptime          | Uptime monitoring                 |
+| Google Groups         | Contact email for the application |
+| Zendesk               | Product Operations                |
 
 ## Infrastructure
 
 ### AWS Account Set-up
+
 #### Managed
+
 - Create new CloudCity accounts for staging and production
+
 #### Manual
+
 - Register for AWS VPN and AWS SSO
-- Create root AWS 
+- Create root AWS
 - Create two AWS accounts, for staging and production
 - If desired, set up AWS Control Tower
 
@@ -50,21 +54,118 @@ Register for the following services:
 - Wire the deploy GitHub Action to be invoked on push to
   the designated branch names
 
-- Obtain Amazon Certificate Manager (ACM) SSL certificates for 
+- Obtain Amazon Certificate Manager (ACM) SSL certificates for
   the domain associated with the application
-    - Configure DNS entries in Cloudflare to facilitate this, 
+  - Configure DNS entries in Cloudflare to facilitate this,
       following instructions from AWS
 
-- Create DNS entries on Cloudflare that point the root domain 
+- Create DNS entries on Cloudflare that point the root domain
   and www subdomain to the load balancer
 
 - Create DNS entries on Cloudflare so that Google Groups
   can be used for mail addresses with the domain name associated
   with the application
 
+### Setting up GitHub Actions
+
+The GitHub Actions CI workflow (`ci.yml`) uses GitHub OIDC to authenticate with AWS.
+
+This has several benefits over using AWS access keys:
+
+- The credentials are short-lived, and can be revoked at any time
+- Fine grained access control for credentials
+
+Read more on OIDC [here](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect).
+
+The simplest way to set this up is using CloudFormation. In the root AWS account, create a CloudFormation stack:
+
+```yaml
+Parameters:
+  GitHubOrg:
+    Type: String
+  RepositoryName:
+    Type: String
+  OIDCProviderArn:
+    Description: Arn for the GitHub OIDC Provider.
+    Default: ""
+    Type: String
+​
+Conditions:
+  CreateOIDCProvider: !Equals
+    - !Ref OIDCProviderArn
+    - ""
+​
+Resources:
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRoleWithWebIdentity
+            Principal:
+              Federated: !If
+                - CreateOIDCProvider
+                - !Ref GithubOidc
+                - !Ref OIDCProviderArn
+            Condition:
+              StringLike:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${RepositoryName}:*
+      Policies: # TODO - Attach any other policies you need to deploy your app (ECR, EB)
+        - PolicyName: DeployToSomeS3Bucket
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:DeleteObject
+                  - s3:GetBucketLocation
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:PutObject
+                  - s3:ListObjectsV2
+                Resource: arn:aws:s3:::admin.form.gov.sg/*
+​
+  GithubOidc:
+    Type: AWS::IAM::OIDCProvider
+    Condition: CreateOIDCProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList:
+        - sts.amazonaws.com
+      ThumbprintList:
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
+​
+Outputs:
+  Role:
+    Value: !GetAtt Role.Arn
+```
+
+The stack creates a role that is assumed by the GitHub Action. The stack provided allows the role to sync with an S3 bucket. You must add any policies required to deploy your application to that role.
+
+The stack will prompt for a few inputs:
+
+- `GitHubOrg`: This should be either `datagovsg` or `opengovsg`
+- `RepositoryName`: The repository the GitHub Action will run on
+- `OIDCProviderARN`:
+  - If a GitHub OIDC provider already exists in the account, use the ARN of the provider
+  - Else leave this field blank, and the stack will create a new provider
+
+After creating the resources, navigate to the GitHub OIDC Provider created, and copy the ARN.
+
+In the GitHub Action's env vars, set:
+
+- `AWS_ROLE_ARN`: the copied ARN
+- `AWS_REGION`: the region of the AWS account
+
+That's it!
+
+> Terraform version coming soon...
+
 ## Monitoring
 
-- Ensure that the application outputs logs that are 
+- Ensure that the application outputs logs that are
   [ndjson-formatted](https://ndjson.org). This makes it very
   convenient for Datadog (and other tools) to parse and index
   your logs.  


### PR DESCRIPTION
## Context

"To harden the security for [the] CI/CD pipeline, [we] can make use of OpenID connect to assume an IAM role in your AWS account rather than creating a IAM user and passing long-lived sensitive secrets in GitHub as secrets." ~ @lamkeewei 

## Deploy Notes

**New environment variables for GITHUB ACTIONS**:

- `AWS_ROLE_ARN` : AWS role GitHub Action will assume
- `AWS_REGION`: AWS region