### PR TITLE
build(ci): drop Elastic Beanstalk, use ECS

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -1,0 +1,104 @@
+name: AWS Deploy
+
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        description: 'AWS region to use'
+        required: true
+        default: 'ap-southeast-1'
+        type: string
+      aws-account-id:
+        description: 'AWS account ID to use'
+        required: true
+        type: string
+      cicd-role:
+        description: 'AWS IAM role to assume by GitHub action runner'
+        required: true
+        type: string
+      ecr-repository:
+        description: 'ECR repository to push image to'
+        required: true
+        type: string
+      ecs-cluster-name:
+        description: 'ECS cluster to deploy to'
+        required: true
+        type: string
+      ecs-service-name:
+        description: 'ECS service to deploy to'
+        required: true
+        type: string
+      ecs-container-name:
+        description: 'Name of container in ECS task definition'
+        required: true
+        type: string
+      codedeploy-application:
+        description: 'CodeDeploy application to use'
+        required: true
+        type: string
+      codedeploy-deployment-group:
+        description: 'CodeDeploy deployment group to use'
+        required: true
+        type: string
+      image-tag:
+        description: 'The locally tagged docker image to push to ECR'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  application-server:
+    name: Application server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ inputs.cicd-role }}
+          role-session-name: github-action-application-deploy
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Push image to ECR
+        id: push-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ inputs.ecr-repository }}
+          IMAGE_TAG: ${{ inputs.image-tag }}
+        run: |
+          docker image tag $IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Replace AWS_ACCOUNT_ID in task definition file
+        id: replace-aws-account-id
+        run: |
+          sed -i 's/<AWS_ACCOUNT_ID>/${{ inputs.aws-account-id }}/g' ecs-task-definition.json
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ecs-task-definition.json
+          container-name: ${{ inputs.ecs-container-name }}
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          cluster: ${{ inputs.ecs-cluster-name }}
+          service: ${{ inputs.ecs-service-name }}
+          wait-for-service-stability: true
+          codedeploy-appspec: appspec.json
+          codedeploy-application: ${{ inputs.codedeploy-application }}
+          codedeploy-deployment-group: ${{ inputs.codedeploy-deployment-group }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,119 +82,90 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./lcov.info
 
-  gatekeep:
-    name: Determine if Build & Deploy is needed
+  proceed:
+    name: Determine if deploy is needed
     outputs:
-      proceed: ${{ steps.determine_proceed.outputs.proceed }}
+      ecs: ${{ steps.determine-ecs.outputs.ecs }}
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - id: determine_proceed
+      - id: determine-ecs
         run: |
-          if [[ -z "${AWS_ROLE_ARN}" || -z "${AWS_REGION}"  ]]; then
-            echo '::set-output name=proceed::false';
-          elif [[ -z "${ECR_REPO}" || -z "${ECR_URL}"  ]]; then
-            echo '::set-output name=proceed::false';
-          elif [[ $GITHUB_REF == $STAGING_BRANCH ]]; then
-            echo '::set-output name=proceed::true';
-          elif [[ $GITHUB_REF == $PRODUCTION_BRANCH ]]; then
-            echo '::set-output name=proceed::true';
+          if [[ -z "${AWS_ROLE_ARN_STAGING}" || -z "${AWS_ACCOUNT_ID_STAGING}" ]]; then
+            echo '::set-output name=ecs::false';
+          elif [[ -z "${AWS_ROLE_ARN_PROD}" || -z "${AWS_ACCOUNT_ID_PROD}" ]]; then
+            echo '::set-output name=ecs::false';
+          elif [[ -z "${ECR_REPO}" || -z "${AWS_REGION}" ]]; then
+            echo '::set-output name=ecs::false';
           else
-            echo '::set-output name=proceed::false';
+            echo '::set-output name=ecs::true';
           fi
         env:
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+          AWS_ACCOUNT_ID_STAGING: ${{ secrets.AWS_ACCOUNT_ID_STAGING }}
+          AWS_ROLE_ARN_STAGING: ${{ secrets.AWS_ROLE_ARN_STAGING }}
+          AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          AWS_ROLE_ARN_PROD: ${{ secrets.AWS_ROLE_ARN_PROD }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           ECR_REPO: ${{ secrets.ECR_REPO }}
-          ECR_URL: ${{ secrets.ECR_URL }}
 
-  build:
-    name: Build and push
+  build-docker:
+    name: Build Docker image
     runs-on: ubuntu-latest
-    needs: [gatekeep]
     outputs:
-      branch: ${{ steps.extract_branch.outputs.branch }}
-      tag: ${{steps.extract_tag.outputs.tag}}
+      branch: ${{ steps.extract-branch.outputs.branch }}
+      tag: ${{steps.extract-tag.outputs.tag}}
     steps:
       - uses: actions/checkout@v2
       - name: Extract branch name
+        id: extract-branch
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
-      - name: Extract ECR tag
+      - name: Extract tag
+        id: extract-tag
         shell: bash
         run: echo "##[set-output name=tag;]$(echo ghactions-${BRANCH}-${SHA})"
-        id: extract_tag
         env:
-          BRANCH: ${{ steps.extract_branch.outputs.branch }}
+          BRANCH: ${{ steps.extract-branch.outputs.branch }}
           SHA: ${{ github.sha }}
-      - run: docker build -t ${{ steps.extract_tag.outputs.tag }} -f Dockerfile .
-      - name: Configure AWS Credentials
-        if: needs.gatekeep.outputs.proceed == 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Push to ECR
-        if: needs.gatekeep.outputs.proceed == 'true'
-        uses: opengovsg/gh-ecr-push@v1
-        with:
-          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          region: ap-southeast-1
-          local-image: ${{ steps.extract_tag.outputs.tag }}
-          image: ${{ secrets.ECR_REPO }}:${{ steps.extract_tag.outputs.tag }}
+      - run: docker build -t ${{ steps.extract-tag.outputs.tag }} -f Dockerfile .
 
-  deploy:
-    name: Deploy to Elastic Beanstalk
+  deploy-ecs:
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
+    name: Deploy to ECS
     runs-on: ubuntu-latest
-    needs: [lint, test, gatekeep, build]
-    if: needs.gatekeep.outputs.proceed == 'true'
+    needs: [lint, test, proceed, build-docker]
+    if: needs.proceed.outputs.ecs == 'true'
     steps:
       - uses: actions/checkout@v2
-      - name: Package Dockerrun.aws.json
-        run: |
-          sed -i -e "s|@REPO|$REPO|g" Dockerrun.aws.json
-          sed -i -e "s|@TAG|$TAG|g" Dockerrun.aws.json
-          zip -r "deploy.zip" Dockerrun.aws.json .ebextensions/
-        env:
-          REPO: ${{secrets.ECR_URL}}/${{secrets.ECR_REPO}}
-          TAG: ${{ needs.build.outputs.tag }}
-      - name: Get timestamp
-        shell: bash
-        run: echo "##[set-output name=timestamp;]$(env TZ=Asia/Singapore date '+%Y%m%d%H%M%S')"
-        id: get_timestamp
-      - name: Get Elastic Beanstalk label
-        shell: bash
-        run: echo "##[set-output name=label;]$(echo ${TAG}-${TIMESTAMP})"
-        id: get_label
-        env:
-          TAG: ${{ needs.build.outputs.tag }}
-          TIMESTAMP: ${{ steps.get_timestamp.outputs.timestamp }}
-      - name: Select Elastic Beanstalk variables
-        run: |
-          if [[ $GITHUB_REF == $STAGING_BRANCH ]]; then
-            echo EB_APP=${{ secrets.EB_APP_STAGING }} >> $GITHUB_ENV;
-            echo EB_ENV=${{ secrets.EB_ENV_STAGING }} >> $GITHUB_ENV;
-          elif [[ $GITHUB_REF == $PRODUCTION_BRANCH ]]; then
-            echo EB_APP=${{ secrets.EB_APP_PRODUCTION }} >> $GITHUB_ENV;
-            echo EB_ENV=${{ secrets.EB_ENV_PRODUCTION }} >> $GITHUB_ENV;
-          fi
-        id: select_eb_vars
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Deploy to ECS Staging
+        id: ecs-staging
+        uses: ./.github/workflows/aws-deploy.yml
+        if: ${{ github.ref }} == ${{ env.STAGING_BRANCH }}
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Deploy to EB
-        uses: opengovsg/beanstalk-deploy@v11
+          aws-region: 'ap-southeast-1'
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID_STAGING }}
+          cicd-role: ${{ secrets.AWS_ROLE_ARN_STAGING }}
+          ecr-repository: ${{ secrets.ECR_REPO }}
+          ecs-cluster-name: 'cluster-application-server'
+          ecs-service-name: 'application-server'
+          ecs-container-name: 'app'
+          codedeploy-application: 'AppECS-cluster-application-server'
+          codedeploy-deployment-group: 'DgpECS-cluster-application-server'
+          image-tag: ${{ needs.build-docker.outputs.tag }}
+      - name: Deploy to ECS Production
+        id: ecs-production
+        uses: ./.github/workflows/aws-deploy.yml
+        if: ${{ github.ref }} == ${{ env.PRODUCTION_BRANCH }}
         with:
-          aws_access_key: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws_secret_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          application_name: ${{ env.EB_APP }}
-          environment_name: ${{ env.EB_ENV }}
-          version_label: ${{ steps.get_label.outputs.label }}
-          region: ap-southeast-1
-          deployment_package: deploy.zip
-          wait_for_deployment: false
-          wait_for_environment_recovery: false
+          aws-region: 'ap-southeast-1'
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          cicd-role: ${{ secrets.AWS_ROLE_ARN_PROD }}
+          ecr-repository: ${{ secrets.ECR_REPO }}
+          ecs-cluster-name: 'cluster-application-server'
+          ecs-service-name: 'application-server'
+          ecs-container-name: 'app'
+          codedeploy-application: 'AppECS-cluster-application-server'
+          codedeploy-deployment-group: 'DgpECS-cluster-application-server'
+          image-tag: ${{ needs.build-docker.outputs.tag }}

--- a/docs/deploying/For-Engineers.md
+++ b/docs/deploying/For-Engineers.md
@@ -47,6 +47,9 @@ Register for the following services:
   - Elastic Container Registry details
   - Environment Names
 
+- Stash secrets in AWS Systems Manager Parameter Store.
+  The actual secrets to store are defined in ecs-task-definition.json
+
 - Use the following branch names for deploying:
   - `staging` - deploys to staging
   - `master` or `release` - deploys to production

--- a/ecs-task-definition.json
+++ b/ecs-task-definition.json
@@ -1,0 +1,147 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        {
+          "name": "TZ",
+          "value": "Asia/Singapore"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "secrets": [
+        {
+          "name": "DB_HOST",
+          "valueFrom": "/app/backend/DB_HOST"
+        },
+        {
+          "name": "DB_NAME",
+          "valueFrom": "/app/backend/DB_NAME"
+        },
+        {
+          "name": "DB_PASSWORD",
+          "valueFrom": "/app/backend/DB_PASSWORD"
+        },
+        {
+          "name": "DB_USERNAME",
+          "valueFrom": "/app/backend/DB_USERNAME"
+        },
+        {
+          "name": "NODE_ENV",
+          "valueFrom": "/app/backend/NODE_ENV"
+        },
+        {
+          "name": "SESSION_SECRET",
+          "valueFrom": "/app/backend/SESSION_SECRET"
+        },
+        {
+          "name": "DD_API_KEY",
+          "valueFrom": "/app/backend/DD_API_KEY"
+        },
+        {
+          "name": "DD_SOURCE",
+          "valueFrom": "/app/backend/DD_SOURCE"
+        },
+        {
+          "name": "DD_SERVICE",
+          "valueFrom": "/app/backend/DD_SERVICE"
+        },
+        {
+          "name": "DD_TAGS",
+          "valueFrom": "/app/backend/DD_TAGS"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/application-server",
+          "awslogs-region": "ap-southeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    },
+    {
+      "name": "dd-agent",
+      "image": "public.ecr.aws/datadog/agent:latest",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "containerPort": 8126,
+          "hostPort": 8126,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": false,
+      "environment": [
+        {
+          "name": "TZ",
+          "value": "Asia/Singapore"
+        },
+        {
+          "name": "DD_APM_NON_LOCAL_TRAFFIC",
+          "value": "true"
+        },
+        {
+          "name": "ECS_FARGATE",
+          "value": "true"
+        },
+        {
+          "name": "DD_APM_ENABLED",
+          "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "datadoghq.com"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "secrets": [
+        {
+          "name": "DD_API_KEY",
+          "valueFrom": "/app/backend/DD_API_KEY"
+        },
+        {
+          "name": "DD_SERVICE",
+          "valueFrom": "/app/backend/DD_SERVICE"
+        },
+        {
+          "name": "DD_TAGS",
+          "valueFrom": "/app/backend/DD_TAGS"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dd-agent",
+          "awslogs-region": "ap-southeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ],
+  "family": "application-server",
+  "networkMode": "awsvpc",
+  "volumes": [],
+  "placementConstraints": [],
+  "runtimePlatform": {
+    "operatingSystemFamily": "LINUX"
+  },
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "taskRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/application-server-role",
+  "executionRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/application-server-role",
+  "cpu": "512",
+  "memory": "1024"
+}


### PR DESCRIPTION
## Context

Given Elastic Beanstalk has fallen out of favour, rework CI to deploy to ECS, assuming separate accounts for staging and prod

- Port aws-deploy GitHub Action from Health Appointment System
- Polish ci steps for names, punctuation
- Remove references to AWS in build and deploy steps, relying on the new aws-deploy action
  - Crucially, handle both push to ECR repo and actual deploy in a single step