### PR TITLE
feat(mailer): allow config via env vars

### DIFF
--- a/backend/src/config/config.schema.ts
+++ b/backend/src/config/config.schema.ts
@@ -30,6 +30,15 @@ export interface ConfigSchema {
     sender_name: string
     email: string
   }
+  mailer: {
+    auth: {
+      type: 'login'
+      user: string
+      pass: string
+    }
+    host: string
+    port: number
+  }
   health: { heapSizeThreshold: number; rssThreshold: number }
 }
 
@@ -166,6 +175,43 @@ export const schema: Schema<ConfigSchema> = {
       env: 'OTP_EMAIL',
       format: String,
       default: 'donotreply@mail.open.gov.sg',
+    },
+  },
+  mailer: {
+    doc:
+      'Mailer configuration for SMTP mail services. ' +
+      'If AWS_REGION is present, this configuration is ignored and ' +
+      'the mailer will use AWS SES via RESTful API instead.',
+    auth: {
+      type: {
+        doc: 'The type of authentication used. Currently, only "login" is supported',
+        format: ['login'],
+        default: 'login',
+      },
+      user: {
+        doc: 'The user to present to the SMTP service',
+        env: 'MAILER_USER',
+        format: String,
+        default: 'mailer-user',
+      },
+      pass: {
+        doc: 'The password to present to the SMTP service',
+        env: 'MAILER_PASSWORD',
+        format: String,
+        default: 'mailer-password',
+      },
+    },
+    host: {
+      doc: 'The server hosting the SMTP service',
+      env: 'MAILER_HOST',
+      format: String,
+      default: 'localhost',
+    },
+    port: {
+      doc: 'The port for the SMTP service',
+      env: 'MAILER_PORT',
+      format: 'port',
+      default: 1025,
     },
   },
   health: {

--- a/backend/src/mailer/mailer.service.ts
+++ b/backend/src/mailer/mailer.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common'
 import { SES } from 'aws-sdk'
-import nodemailer, { SendMailOptions, Transporter } from 'nodemailer'
+import nodemailer, {
+  SendMailOptions,
+  SentMessageInfo,
+  Transporter,
+} from 'nodemailer'
 
 import { ConfigService } from '../config/config.service'
 
@@ -18,12 +22,12 @@ export class MailerService {
         }),
       })
     : nodemailer.createTransport({
-        port: 1025,
-        host: 'localhost',
-        ignoreTLS: true,
+        ...this.config.get('mailer'),
+        secure: !this.config.isDevEnv,
+        ignoreTLS: this.config.isDevEnv,
       })
 
-  sendMail = async (mailOptions: SendMailOptions): Promise<void> => {
+  sendMail = async (mailOptions: SendMailOptions): Promise<SentMessageInfo> => {
     return this.mailer.sendMail(mailOptions)
   }
 }

--- a/docs/deploying/for-everyone.md
+++ b/docs/deploying/for-everyone.md
@@ -46,6 +46,10 @@ Go back to the database tab, and copy each connection parameter to the
 corresponding environment variable as shown in the screenshots below.
 Also add `NODE_ENV`, and set that to `production`.
 
+(If you wish to use email OTPs for your application, sign up for an email
+service like SendGrid, then input the mail connection parameters as
+the relevant environment variables documented [here](../../backend/src/config/config.schema.ts).
+
 ![DigitalOcean - Database Params](images/digitalocean/db-params.png)
 
 ![DigitalOcean - Environment Variables](images/digitalocean/env-vars.png)

--- a/docs/deploying/for-hustlers.md
+++ b/docs/deploying/for-hustlers.md
@@ -140,6 +140,11 @@ NODE_ENV=staging
 Secrets are staged for the first deployment
 ```
 
+(If you wish to use email OTPs for your application, sign up for an email
+service like SendGrid, then input the mail connection parameters as
+the relevant environment variables documented [here](../../backend/src/config/config.schema.ts).
+
+
 ### Deploying with GitHub Actions
 
 From the dashboard, go to [Account -> Access Tokens](https://fly.io/user/personal_access_tokens)


### PR DESCRIPTION
## Context
Allow mailer to be configurable using environment variables, so that we can deploy ts-template to environments other than AWS and use mail services that use SMTPS. AWS deployments will still require the use of SES over REST API.

## Approach
- Move hard-coded nodemailer config for dev environments to dev-level defaults in `config.schema`
- Allow these to be changed through the env vars `MAILER_HOST` and `MAILER_PORT`
- Introduce `MAILER_USER` and `MAILER_PASSWORD` to allow users to supply credentials to SMTP services in production
- Update the guides to reflect the changes

## Deploy Notes

### New environment variables

- `MAILER_*` : for users to configure SMTP credentials in production
