### PR TITLE
build(ci): hardcode `NODE_ENV`, have discrete `DD_TAGS_AGENT`

### DIFF
--- a/ecs-task-definition.json
+++ b/ecs-task-definition.json
@@ -15,6 +15,10 @@
         {
           "name": "TZ",
           "value": "Asia/Singapore"
+        },
+        {
+          "name": "NODE_ENV",
+          "value": "production"
         }
       ],
       "mountPoints": [],
@@ -35,10 +39,6 @@
         {
           "name": "DB_USERNAME",
           "valueFrom": "/app/backend/DB_USERNAME"
-        },
-        {
-          "name": "NODE_ENV",
-          "valueFrom": "/app/backend/NODE_ENV"
         },
         {
           "name": "SESSION_SECRET",
@@ -117,7 +117,7 @@
         },
         {
           "name": "DD_TAGS",
-          "valueFrom": "/app/backend/DD_TAGS"
+          "valueFrom": "/app/backend/DD_TAGS_AGENT"
         }
       ],
       "logConfiguration": {


### PR DESCRIPTION
- Declare `NODE_ENV` as `production` for all deployed environments
- Pass new `DD_TAGS_AGENT` param to dd-agent as `DD_TAGS`
