### PR TITLE
build(ci): reorg deploy actions for readability

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -9,15 +9,13 @@ on:
       cicd-role:
         description: 'AWS IAM role to assume by GitHub action runner'
         required: true
+      aws-region:
+        description: 'AWS region to use'
+        required: true
       ecr-repository:
         description: 'ECR repository to push image to'
         required: true
     inputs:
-      aws-region:
-        description: 'AWS region to use'
-        required: true
-        default: 'ap-southeast-1'
-        type: string
       ecs-cluster-name:
         description: 'ECS cluster to deploy to'
         required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,158 +12,34 @@ jobs:
     name: Build, Test, Lint
     uses: ./.github/workflows/build.yml
 
-  proceed-staging:
-    name: Determine if staging deploy is needed
-    outputs:
-      ecs: ${{ steps.determine-ecs.outputs.ecs }}
-      fly: ${{ steps.determine-fly.outputs.fly }}
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    steps:
-      - id: determine-ecs
-        run: |
-          if [[ -z "${AWS_ROLE_ARN_STAGING}" || -z "${AWS_ACCOUNT_ID_STAGING}" ]]; then
-            echo '::set-output name=ecs::false';
-          elif [[ -z "${ECR_REPO}" || -z "${AWS_REGION}" ]]; then
-            echo '::set-output name=ecs::false';
-          else
-            echo '::set-output name=ecs::true';
-          fi
-        env:
-          AWS_ACCOUNT_ID_STAGING: ${{ secrets.AWS_ACCOUNT_ID_STAGING }}
-          AWS_ROLE_ARN_STAGING: ${{ secrets.AWS_ROLE_ARN_STAGING }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          ECR_REPO: ${{ secrets.ECR_REPO }}
-      - id: determine-fly
-        run: |
-          if [[ -z "${APP_NAME_STAGING}" || -z "${ORG_NAME_STAGING}" ]]; then
-            echo '::set-output name=fly::false';
-          elif [[ -z "${FLY_API_TOKEN}" ]]; then
-            echo '::set-output name=fly::false';
-          else
-            echo '::set-output name=fly::true';
-          fi
-        env:
-          APP_NAME_STAGING: ${{ secrets.APP_NAME_STAGING }}
-          ORG_NAME_STAGING: ${{ secrets.ORG_NAME_STAGING }}
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  proceed-production:
-    name: Determine if production deploy is needed
-    outputs:
-      ecs: ${{ steps.determine-ecs.outputs.ecs }}
-      fly: ${{ steps.determine-fly.outputs.fly }}
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    steps:
-      - id: determine-ecs
-        run: |
-          if [[ -z "${AWS_ROLE_ARN_PROD}" || -z "${AWS_ACCOUNT_ID_PROD}" ]]; then
-            echo '::set-output name=ecs::false';
-          elif [[ -z "${ECR_REPO}" || -z "${AWS_REGION}" ]]; then
-            echo '::set-output name=ecs::false';
-          else
-            echo '::set-output name=ecs::true';
-          fi
-        env:
-          AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          AWS_ROLE_ARN_PROD: ${{ secrets.AWS_ROLE_ARN_PROD }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          ECR_REPO: ${{ secrets.ECR_REPO }}
-      - id: determine-fly
-        run: |
-          if [[ -z "${APP_NAME_PROD}" || -z "${ORG_NAME_PROD}" ]]; then
-            echo '::set-output name=fly::false';
-          elif [[ -z "${FLY_API_TOKEN}" ]]; then
-            echo '::set-output name=fly::false';
-          else
-            echo '::set-output name=fly::true';
-          fi
-        env:
-          APP_NAME_PROD: ${{ secrets.APP_NAME_PROD }}
-          ORG_NAME_PROD: ${{ secrets.ORG_NAME_PROD }}
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  generate-docker-tag:
-    name: Generate Docker tag
-    runs-on: ubuntu-latest
-    outputs:
-      tag: ${{steps.generate-tag.outputs.tag}}
-    steps:
-      - name: Generate tag
-        id: generate-tag
-        shell: bash
-        run: echo "##[set-output name=tag;]$(echo ghactions-${BRANCH}-${SHA})"
-        env:
-          BRANCH: ${{ github.ref_name }}
-          SHA: ${{ github.sha }}
-
-  deploy-ecs-staging:
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
-    name: Deploy to ECS Staging
-    needs: [build, proceed-staging, generate-docker-tag]
-    if: needs.proceed-staging.outputs.ecs == 'true' && github.ref_name == 'staging'
-    uses: ./.github/workflows/aws-deploy.yml
+  deploy-staging:
+    name: Deploy to Staging
+    needs: [build]
+    if: github.ref_name == 'staging'
+    uses: ./.github/workflows/deploy.yml
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID_STAGING }}
-      cicd-role: ${{ secrets.AWS_ROLE_ARN_STAGING }}
-      ecr-repository: ${{ secrets.ECR_REPO }}
+      aws-role-arn: ${{ secrets.AWS_ROLE_ARN_STAGING }}
+      aws-region: ${{ secrets.AWS_REGION }}
+      aws-ecr-repo: ${{ secrets.ECR_REPO }}
+      fly-org-name: ${{ secrets.ORG_NAME_STAGING }}
+      fly-app-name: ${{ secrets.APP_NAME_STAGING }}
+      fly-api-token: ${{ secrets.FLY_API_TOKEN }}
     with:
-      aws-region: 'ap-southeast-1'
-      ecs-cluster-name: 'cluster-application-server'
-      ecs-service-name: 'application-server'
-      ecs-container-name: 'app'
-      codedeploy-application: 'AppECS-cluster-application-server'
-      codedeploy-deployment-group: 'DgpECS-cluster-application-server'
-      image-tag: ${{ needs.generate-docker-tag.outputs.tag }}
+      image-tag: ghactions-${{ github.ref_name }}-${{ github.sha }}
 
-  deploy-ecs-production:
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
-    name: Deploy to ECS Production
-    needs: [build, proceed-production, generate-docker-tag]
-    if: needs.proceed-production.outputs.ecs == 'true' && github.ref_name == 'production'
-    uses: ./.github/workflows/aws-deploy.yml
+  deploy-production:
+    name: Deploy to Production
+    needs: [build]
+    if: github.ref_name == 'production'
+    uses: ./.github/workflows/deploy.yml
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-      cicd-role: ${{ secrets.AWS_ROLE_ARN_PROD }}
-      ecr-repository: ${{ secrets.ECR_REPO }}
-    with:
-      aws-region: 'ap-southeast-1'
-      ecs-cluster-name: 'cluster-application-server'
-      ecs-service-name: 'application-server'
-      ecs-container-name: 'app'
-      codedeploy-application: 'AppECS-cluster-application-server'
-      codedeploy-deployment-group: 'DgpECS-cluster-application-server'
-      image-tag: ${{ needs.generate-docker-tag.outputs.tag }}
-
-  deploy-fly-staging:
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
-    name: Deploy to Fly.io Staging
-    needs: [build, proceed-staging, generate-docker-tag]
-    if: needs.proceed-staging.outputs.fly == 'true' && github.ref_name == 'staging'
-    uses: ./.github/workflows/fly-deploy.yml
-    secrets:
-      app-name: ${{ secrets.APP_NAME_STAGING }}
+      aws-role-arn: ${{ secrets.AWS_ROLE_ARN_PROD }}
+      aws-region: ${{ secrets.AWS_REGION }}
+      aws-ecr-repo: ${{ secrets.ECR_REPO }}
+      fly-org-name: ${{ secrets.ORG_NAME_PROD }}
+      fly-app-name: ${{ secrets.APP_NAME_PROD }}
       fly-api-token: ${{ secrets.FLY_API_TOKEN }}
     with:
-      image-tag: ${{ needs.generate-docker-tag.outputs.tag }}
-
-  deploy-fly-production:
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
-    name: Deploy to Fly.io Production
-    needs: [build, proceed-production, generate-docker-tag]
-    if: needs.proceed-production.outputs.fly == 'true' && github.ref_name == 'production'
-    uses: ./.github/workflows/fly-deploy.yml
-    secrets:
-      app-name: ${{ secrets.APP_NAME_PROD }}
-      fly-api-token: ${{ secrets.FLY_API_TOKEN }}
-    with:
-      image-tag: ${{ needs.generate-docker-tag.outputs.tag }}
+      image-tag: ghactions-${{ github.ref_name }}-${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,102 @@
+name: deploy
+on:
+  workflow_call:
+    secrets:
+      aws-account-id:
+        description: 'AWS account ID to use'
+        required: false
+      aws-role-arn:
+        description: 'AWS IAM role to assume by GitHub action runner'
+        required: false
+      aws-region:
+        description: 'AWS Region'
+        required: false
+      aws-ecr-repo:
+        description: 'ECR repository to push image to'
+        required: false
+      fly-org-name:
+        description: 'Fly.io organisation name'
+        required: false
+      fly-app-name:
+        description: 'Fly.io application name'
+        required: false
+      fly-api-token:
+        description: 'API Token for Fly.io'
+        required: false
+    inputs:
+      image-tag:
+        description: 'The locally tagged docker image to push to Fly.io'
+        required: true
+        type: string
+
+jobs:
+  proceed:
+    name: Determine if deploy is needed
+    outputs:
+      ecs: ${{ steps.determine-ecs.outputs.ecs }}
+      fly: ${{ steps.determine-fly.outputs.fly }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - id: determine-ecs
+        run: |
+          if [[ -z "${AWS_ROLE_ARN}" || -z "${AWS_ACCOUNT_ID}" ]]; then
+            echo '::set-output name=ecs::false';
+          elif [[ -z "${AWS_ECR_REPO}" || -z "${AWS_REGION}" ]]; then
+            echo '::set-output name=ecs::false';
+          else
+            echo '::set-output name=ecs::true';
+          fi
+        env:
+          AWS_ACCOUNT_ID: ${{ secrets.aws-account-id }}
+          AWS_ROLE_ARN: ${{ secrets.aws-role-arn }}
+          AWS_REGION: ${{ secrets.aws-region }}
+          AWS_ECR_REPO: ${{ secrets.aws-ecr-repo }}
+      - id: determine-fly
+        run: |
+          if [[ -z "${FLY_APP_NAME}" || -z "${FLY_ORG_NAME}" ]]; then
+            echo '::set-output name=fly::false';
+          elif [[ -z "${FLY_API_TOKEN}" ]]; then
+            echo '::set-output name=fly::false';
+          else
+            echo '::set-output name=fly::true';
+          fi
+        env:
+          FLY_APP_NAME: ${{ secrets.fly-app-name }}
+          FLY_ORG_NAME: ${{ secrets.fly-org-name }}
+          FLY_API_TOKEN: ${{ secrets.fly-api-token }}
+
+  ecs:
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
+    name: ECS
+    needs: [proceed]
+    if: needs.proceed.outputs.ecs == 'true'
+    uses: ./.github/workflows/aws-deploy.yml
+    secrets:
+      aws-account-id: ${{ secrets.aws-account-id }}
+      cicd-role: ${{ secrets.aws-role-arn }}
+      aws-region: ${{ secrets.aws-region }}
+      ecr-repository: ${{ secrets.aws-ecr-repo }}
+    with:
+      ecs-cluster-name: 'cluster-application-server'
+      ecs-service-name: 'application-server'
+      ecs-container-name: 'app'
+      codedeploy-application: 'AppECS-cluster-application-server'
+      codedeploy-deployment-group: 'DgpECS-cluster-application-server'
+      image-tag: ${{ inputs.image-tag }}
+
+  fly:
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
+    name: Fly.io
+    needs: [proceed]
+    if: needs.proceed.outputs.fly == 'true'
+    uses: ./.github/workflows/fly-deploy.yml
+    secrets:
+      app-name: ${{ secrets.fly-app-name }}
+      fly-api-token: ${{ secrets.fly-api-token }}
+    with:
+      image-tag: ${{ inputs.image-tag }}


### PR DESCRIPTION
- Drop generate-docker-tag step, supply tag directly
- Create deploy workflow call, wrapping around ECS/Fly/Proceed steps
- Replace deploy-related steps in ci.yml with new workflow calls
