### PR TITLE
chore: hardcode DD_SOURCE env var

### DIFF
--- a/ecs-task-definition.json
+++ b/ecs-task-definition.json
@@ -19,6 +19,10 @@
         {
           "name": "NODE_ENV",
           "value": "production"
+        },
+        {
+          "name": "DD_SOURCE",
+          "value": "nodejs"
         }
       ],
       "mountPoints": [],
@@ -47,10 +51,6 @@
         {
           "name": "DD_API_KEY",
           "valueFrom": "/app/backend/DD_API_KEY"
-        },
-        {
-          "name": "DD_SOURCE",
-          "valueFrom": "/app/backend/DD_SOURCE"
         },
         {
           "name": "DD_SERVICE",
@@ -137,9 +137,7 @@
   "runtimePlatform": {
     "operatingSystemFamily": "LINUX"
   },
-  "requiresCompatibilities": [
-    "FARGATE"
-  ],
+  "requiresCompatibilities": ["FARGATE"],
   "taskRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/application-server-role",
   "executionRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/application-server-role",
   "cpu": "512",


### PR DESCRIPTION
## Context

Don't think `DD_SOURCE` is needed inside the container as it can't be found on https://docs.datadoghq.com/containers/docker/?tab=standard#environment-variables. Removing to save the trouble of having to set it in SSM.