### PR TITLE
chore: build Docker images in forked repos by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,6 @@ jobs:
   build-docker:
     name: Build Docker image
     runs-on: ubuntu-latest
-    if: github.repository == 'opengovsg/ts-template'
     steps:
       - uses: actions/checkout@v3
       - run: docker build -f Dockerfile .


### PR DESCRIPTION
## Context

We'd like newly forked repos to build Docker images by default so that we can provide the "no manual steps" app creation experience. This PR reverts c3f3026b19937bc553f36c316b8f4634e83d93bc to achieve that.