### PR TITLE
chore(mailer): log mail instead of sending in prod

### DIFF
--- a/backend/src/auth/__tests__/auth.controller.spec.ts
+++ b/backend/src/auth/__tests__/auth.controller.spec.ts
@@ -1,10 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { getRepositoryToken } from '@nestjs/typeorm'
-import { PinoLogger } from 'nestjs-pino'
+import { getLoggerToken } from 'nestjs-pino'
 
 import { ConfigModule } from '../../config/config.module'
 import { Session, User } from '../../database/entities'
-import { MailerModule } from '../../mailer/mailer.module'
+import { MailerService } from '../../mailer/mailer.service'
 import { OtpModule } from '../../otp/otp.module'
 import { AuthController } from '../auth.controller'
 import { AuthService } from '../auth.service'
@@ -15,10 +15,11 @@ describe('AuthController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [ConfigModule, OtpModule, MailerModule],
+      imports: [ConfigModule, OtpModule],
       controllers: [AuthController],
       providers: [
         AuthService,
+        MailerService,
         {
           provide: getRepositoryToken(User),
           useValue: mockModel,
@@ -28,11 +29,15 @@ describe('AuthController', () => {
           useValue: mockModel,
         },
         {
-          provide: `${PinoLogger.name}:${AuthController.name}`,
+          provide: getLoggerToken(AuthController.name),
           useValue: console,
         },
         {
-          provide: `${PinoLogger.name}:${AuthService.name}`,
+          provide: getLoggerToken(AuthService.name),
+          useValue: console,
+        },
+        {
+          provide: getLoggerToken(MailerService.name),
           useValue: console,
         },
       ],

--- a/backend/src/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/auth/__tests__/auth.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { getRepositoryToken } from '@nestjs/typeorm'
-import { PinoLogger } from 'nestjs-pino'
+import { getLoggerToken } from 'nestjs-pino'
 
 import { ConfigService } from '../../config/config.service'
 import { Session, User } from '../../database/entities'
@@ -28,7 +28,11 @@ describe('AuthService', () => {
           useValue: mockModel,
         },
         {
-          provide: `${PinoLogger.name}:${AuthService.name}`,
+          provide: getLoggerToken(AuthService.name),
+          useValue: console,
+        },
+        {
+          provide: getLoggerToken(MailerService.name),
           useValue: console,
         },
       ],

--- a/backend/src/mailer/mailer.service.ts
+++ b/backend/src/mailer/mailer.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { SES } from 'aws-sdk'
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
 import nodemailer, {
   SendMailOptions,
   SentMessageInfo,
@@ -10,24 +11,48 @@ import { ConfigService } from '../config/config.service'
 
 @Injectable()
 export class MailerService {
-  constructor(private config: ConfigService) {}
+  constructor(
+    private config: ConfigService,
+    @InjectPinoLogger(MailerService.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
-  private mailer: Pick<Transporter, 'sendMail'> = this.config.get('awsRegion')
-    ? nodemailer.createTransport({
-        SES: new SES({
-          region: this.config.get('awsRegion'),
-          httpOptions: {
-            connectTimeout: 20000,
-          },
-        }),
-      })
+  // FIXME: Once mail services are available, remove this block:
+  private mailer: Pick<Transporter, 'sendMail'> = !this.config.isDevEnv
+    ? {
+        sendMail: (mailOptions: SendMailOptions) => {
+          this.logger.warn(
+            `REMOVE ME ONCE ${SES.name} OR MAIL IS IN PLACE Logging mail: ${
+              mailOptions.html?.toString() ?? ''
+            }`,
+          )
+          return Promise.resolve()
+        },
+      }
     : nodemailer.createTransport({
         ...this.config.get('mailer'),
         secure: !this.config.isDevEnv,
         ignoreTLS: this.config.isDevEnv,
       })
 
+  // FIXME: Once mail services are available, uncomment this block:
+  // private mailer: Pick<Transporter, 'sendMail'> = this.config.get('awsRegion')
+  //   ? nodemailer.createTransport({
+  //       SES: new SES({
+  //         region: this.config.get('awsRegion'),
+  //         httpOptions: {
+  //           connectTimeout: 20000,
+  //         },
+  //       }),
+  //     })
+  //   : nodemailer.createTransport({
+  //       ...this.config.get('mailer'),
+  //       secure: !this.config.isDevEnv,
+  //       ignoreTLS: this.config.isDevEnv,
+  //     })
+
   sendMail = async (mailOptions: SendMailOptions): Promise<SentMessageInfo> => {
+    this.logger.info('Sending mail')
     return this.mailer.sendMail(mailOptions)
   }
 }


### PR DESCRIPTION
## Context

When deploying ts-template for the first time to production, mail services may not have been set up, due to the slow and arduous process of requesting for mail services like AWS' SES, which requires manual support tickets to fully enable.

Closes #2226

## Approach

As a (somewhat questionable) workaround, simply log mails instead of sending them to any mail service.

This has the nice side-effect of forcing new products to go through the process of making a code change and making environment changes, thereby familiarising them with the set-up.

TODO: Write a guide that explicitly walks them through said process.
