### PR TITLE
fix(auth): validate login emails

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,15 +2,17 @@
 import 'tracing'
 
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common'
+import { APP_PIPE } from '@nestjs/core'
 import { ServeStaticModule } from '@nestjs/serve-static'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { ApiModule } from 'api.module'
 import { ConfigModule } from 'config/config.module'
 import { ConfigService } from 'config/config.service'
+import { LoggedValidationPipe } from 'core/providers/logged-validation.pipe'
 import { DatabaseConfigService } from 'database/database-config.service'
 import { HelmetMiddleware } from 'middlewares/helmet.middleware'
 import { SessionMiddleware } from 'middlewares/session.middleware'
-import { LoggerModule } from 'nestjs-pino'
+import { LoggerModule, PinoLogger } from 'nestjs-pino'
 import { join } from 'path'
 import { TraceIdProvider } from 'tracing/trace-id.provider'
 
@@ -63,6 +65,15 @@ const FRONTEND_PATH = join(__dirname, '..', '..', 'frontend', 'build')
         },
       },
     }),
+  ],
+  providers: [
+    {
+      provide: APP_PIPE,
+      useClass: LoggedValidationPipe,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      inject: [PinoLogger],
+    },
   ],
 })
 export class AppModule implements NestModule {

--- a/backend/src/core/providers/logged-validation.pipe.ts
+++ b/backend/src/core/providers/logged-validation.pipe.ts
@@ -1,0 +1,45 @@
+import 'dotenv/config'
+
+import { BadRequestException, Injectable, ValidationPipe } from '@nestjs/common'
+import { ValidationError } from 'class-validator'
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
+
+@Injectable()
+export class LoggedValidationPipe extends ValidationPipe {
+  constructor(
+    @InjectPinoLogger(ValidationPipe.name)
+    private readonly logger: PinoLogger,
+  ) {
+    super({
+      whitelist: true,
+      transform: true,
+      exceptionFactory: (errors: ValidationError[]) => {
+        errors = this.flattenErrors(errors).filter(
+          (errors) => !!errors.constraints,
+        )
+        this.logger.info(JSON.stringify(errors))
+        const allErrors = errors
+          .flatMap((e) => Object.values(e.constraints ?? {}))
+          .join('\n')
+        return new BadRequestException(allErrors)
+      },
+    })
+  }
+
+  private flattenErrors(
+    errors: ValidationError[],
+  ): Omit<ValidationError, 'children'>[] {
+    const children: Omit<ValidationError, 'children'>[] = errors
+      .filter((error) => error.children?.length)
+      // Filter guarantees that error.children is non-null
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      .map((error) => this.flattenErrors(error.children!))
+      .flat()
+    const result: Omit<ValidationError, 'children'>[] = errors.map((error) => {
+      const { children, ...rest } = error
+      return rest
+    })
+    result.push(...children)
+    return result
+  }
+}

--- a/backend/src/database/entities/user.entity.ts
+++ b/backend/src/database/entities/user.entity.ts
@@ -8,6 +8,8 @@ import {
   UpdateDateColumn,
 } from 'typeorm'
 
+import { IsGovSgEmail } from '~shared/decorators/is-gov-sg-email'
+
 @Entity({ name: 'users' })
 export class User {
   @PrimaryGeneratedColumn()
@@ -18,6 +20,7 @@ export class User {
     unique: true,
     where: '"deletedAt" IS NULL',
   })
+  @IsGovSgEmail()
   email: string
 
   @CreateDateColumn({ type: 'timestamptz' })

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -12,8 +12,7 @@ import {
   useBreakpointValue,
 } from '@chakra-ui/react'
 
-const emailRegex =
-  /[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+/
+import { isGovSgEmail } from '~shared/decorators/is-gov-sg-email'
 
 export type LoginFormInputs = {
   email: string
@@ -28,12 +27,7 @@ export const LoginForm = ({ onSubmit }: LoginFormProps): JSX.Element => {
     useForm<LoginFormInputs>()
 
   const validateEmail = useCallback((value: string) => {
-    const isValidEmail = emailRegex.test(value)
-    if (!isValidEmail) {
-      return 'Please enter a valid email'
-    }
-
-    const isGovDomain = value.split('@').pop()?.includes('gov.sg')
+    const isGovDomain = isGovSgEmail(value)
     return isGovDomain || 'Please sign in with a gov.sg email address.'
   }, [])
 
@@ -61,7 +55,7 @@ export const LoginForm = ({ onSubmit }: LoginFormProps): JSX.Element => {
         <Input
           autoComplete="email"
           autoFocus
-          placeholder="e.g. jane@data.gov.sg"
+          placeholder="e.g. user@agency.gov.sg"
           {...register('email', {
             required: 'Please enter an email address',
             validate: validateEmail,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MIT",
+      "dependencies": {
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.13.2"
+      },
       "devDependencies": {
         "@commitlint/cli": "^17.3.0",
         "@commitlint/config-conventional": "^17.3.0",
@@ -1103,6 +1107,20 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz",
+      "integrity": "sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==",
+      "dependencies": {
+        "libphonenumber-js": "^1.9.43",
+        "validator": "^13.7.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -2782,6 +2800,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.14",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.14.tgz",
+      "integrity": "sha512-McGS7GV/WjJ2KjfOGhJU1oJn29RYeo7Q+RpANRbUNMQ9gj5XArpbjurSuyYPTejFwbaUojstQ4XyWCrAzGOUXw=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -4158,6 +4181,14 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -5071,6 +5102,20 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "class-validator": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz",
+      "integrity": "sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==",
+      "requires": {
+        "libphonenumber-js": "^1.9.43",
+        "validator": "^13.7.0"
+      }
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -6320,6 +6365,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.10.14",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.14.tgz",
+      "integrity": "sha512-McGS7GV/WjJ2KjfOGhJU1oJn29RYeo7Q+RpANRbUNMQ9gj5XArpbjurSuyYPTejFwbaUojstQ4XyWCrAzGOUXw=="
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -7324,6 +7374,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "dependencies": {
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.13.2"
   }
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -27,6 +27,5 @@
       "prettier --write",
       "eslint --fix"
     ]
-  },
-  "dependencies": {}
+  }
 }

--- a/shared/src/decorators/__tests__/is-gov-sg-email.spec.ts
+++ b/shared/src/decorators/__tests__/is-gov-sg-email.spec.ts
@@ -1,0 +1,38 @@
+import { validate } from 'class-validator'
+
+import { IsGovSgEmail } from '../is-gov-sg-email'
+
+describe('IsGovSgEmail', () => {
+  class TestClass {
+    @IsGovSgEmail()
+    email: unknown
+  }
+
+  it('rejects non-strings', async () => {
+    const test = new TestClass()
+    test.email = 2
+    const result = await validate(test)
+    expect(result.length).toBe(1)
+  })
+
+  it('rejects bad emails', async () => {
+    const test = new TestClass()
+    test.email = 'bad@gmail.com,victim@open.gov.sg'
+    const result = await validate(test)
+    expect(result.length).toBe(1)
+  })
+
+  it('rejects non-gov.sg emails', async () => {
+    const test = new TestClass()
+    test.email = 'bad@gmail.com'
+    const result = await validate(test)
+    expect(result.length).toBe(1)
+  })
+
+  it('accepts gov.sg emails', async () => {
+    const test = new TestClass()
+    test.email = 'team@open.gov.sg'
+    const result = await validate(test)
+    expect(result).toStrictEqual([])
+  })
+})

--- a/shared/src/decorators/is-gov-sg-email.ts
+++ b/shared/src/decorators/is-gov-sg-email.ts
@@ -1,0 +1,25 @@
+import { registerDecorator, ValidationOptions } from 'class-validator'
+import { isEmail } from 'class-validator'
+
+export const isGovSgEmail = (value: unknown, options?: ValidationOptions) => {
+  return (
+    typeof value === 'string' &&
+    isEmail(value, options) &&
+    value.toString().endsWith('.gov.sg')
+  )
+}
+
+export const IsGovSgEmail = (options?: ValidationOptions) => {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  return (object: Object, propertyName: string) => {
+    registerDecorator({
+      name: 'isGovSgEmail',
+      target: object.constructor,
+      propertyName,
+      options,
+      validator: {
+        validate: (value: unknown) => isGovSgEmail(value, options),
+      },
+    })
+  }
+}

--- a/shared/src/types/auth.dto.ts
+++ b/shared/src/types/auth.dto.ts
@@ -1,4 +1,8 @@
-export interface GenerateOtpDto {
+import { IsGovSgEmail } from '../decorators/is-gov-sg-email'
+export class GenerateOtpDto {
+  @IsGovSgEmail({
+    message: 'This does not appear to be a gov.sg email address',
+  })
   email: string
 }
 


### PR DESCRIPTION
## Context and Approach

Use class-validator and class-transformer to validate VerifyOtpRequest and form validation to ensure that the login is a valid gov.sg email. This guards against a bad actor providing input that is not an email address (eg, two email addresses separated by ,), but can still be used by nodemailer

- install class-validator and class-transformer to root directory to allow backend and shared to use the same instances for validation
- create a new `IsGovSgEmail()` decorator that builds on top of `IsEmail()` to ensure that an address is a valid gov.sg email
- add a validation pipe to the app to enable request validation
- ensure that the emails in GenerateOtpDto and User are annotated with `IsGovSgEmail()` and hence validated, along with mail input

## Deploy Notes

### New dependencies
- `class-validator` and `class-transformer` : used for validation of login emails
