### PR TITLE
chore: run lint-staged hooks on prepush instead of precommit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm run on-backend -- pre-commit && npm run on-frontend -- pre-commit

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+npm run on-backend -- pre-push && \
+npm run on-frontend -- pre-push && \
+npm run on-shared -- pre-push && \
 npx commitlint --from origin/develop --to HEAD --verbose

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,18 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run on-backend -- pre-push && \
-npm run on-frontend -- pre-push && \
-npm run on-shared -- pre-push && \
-npx commitlint --from origin/develop --to HEAD --verbose
+
+while read local_ref local_sha remote_ref remote_sha
+do
+
+  # Get the current branch name from fully qualified ref
+  # e.g. refs/heads/main -> main
+  SRC=${local_ref#refs/heads/}
+  DEST=$1/${remote_ref#refs/heads/}
+
+  npm run on-backend -- pre-push -- --diff=$SRC...$DEST && \
+  npm run on-frontend -- pre-push -- --diff=$SRC...$DEST && \
+  npm run on-shared -- pre-push -- --diff=$SRC...$DEST && \
+  npx commitlint --from origin/develop --to HEAD --verbose
+
+done

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint --ext ts,tsx,js,jsx . && prettier -c \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint --fix --ext ts,tsx,js,jsx . && prettier -c --write \"src/**/*.{ts,tsx}\"",
-    "pre-commit": "lint-staged",
+    "pre-push": "lint-staged",
     "prebuild": "rimraf build",
     "build": "nest build",
     "preload": "echo ENV=${ENV:-'development'} && dotenv -c ${ENV:-'development'} --",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "wretch": "^2.3.0"
       },
       "devDependencies": {
-        "@snyk/protect": "*",
+        "@snyk/protect": "latest",
         "@storybook/addon-actions": "^6.5.15",
         "@storybook/addon-essentials": "^6.5.15",
         "@storybook/addon-interactions": "^6.5.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,7 +70,7 @@
     "build-storybook": "build-storybook -s public",
     "lint": "eslint ./ --ignore-path .gitignore && prettier . -c",
     "lint:fix": "eslint ./ --ignore-path .gitignore --fix && prettier . -c --write",
-    "pre-commit": "lint-staged",
+    "pre-push": "lint-staged",
     "snyk-protect": "snyk-protect",
     "prepare": "npm run snyk-protect"
   },

--- a/shared/package.json
+++ b/shared/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "pre-commit": "lint-staged",
+    "pre-push": "lint-staged",
     "lint": "eslint --ext ts,tsx,js,jsx . && prettier -c \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint --fix --ext ts,tsx,js,jsx . && prettier -c --write \"src/**/*.{ts,tsx}\"",
     "build": "tsc --build --clean && tsc --build tsconfig.build.json --force",


### PR DESCRIPTION
## Context
Running on every commit seems excessive and is actually quite slow.
Should be sufficient to run them on pre-push, I think?

Updates pre-push git hook to run `lint-staged` on the diff between the source and destination branches. 