### PR TITLE
fix(config): set OTP_EMAIL default, update npm to facilitate Postman

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,7 +14,7 @@
         "@nestjs/serve-static": "^3.0.0",
         "@nestjs/terminus": "^9.1.4",
         "@nestjs/typeorm": "^9.0.1",
-        "@opengovsg/postmangovsg-client": "^0.0.7",
+        "@opengovsg/postmangovsg-client": "^0.0.8",
         "connect-typeorm": "^2.0.0",
         "convict": "^6.2.4",
         "dd-trace": "^3.10.0",
@@ -2849,9 +2849,9 @@
       }
     },
     "node_modules/@opengovsg/postmangovsg-client": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opengovsg/postmangovsg-client/-/postmangovsg-client-0.0.7.tgz",
-      "integrity": "sha512-aUzdOPkTiNgA7gQyI1FGJbXryplslvfT4M5MBBMaek62mIbDD77pwFQHFZ5L4/wLbvaKm1VIPfe1Bs6IjqCl7A==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@opengovsg/postmangovsg-client/-/postmangovsg-client-0.0.8.tgz",
+      "integrity": "sha512-KNeoe+nl+pZEPx0cgRujSJnn5xW8AKZTbBWPv7BJZt8QNEBiEhTBcr7ZHfKfsUn8tacnDnTEmybrcgIBSoJpxg==",
       "hasInstallScript": true,
       "peerDependencies": {
         "axios": "^1.2.2",
@@ -13542,9 +13542,9 @@
       }
     },
     "@opengovsg/postmangovsg-client": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opengovsg/postmangovsg-client/-/postmangovsg-client-0.0.7.tgz",
-      "integrity": "sha512-aUzdOPkTiNgA7gQyI1FGJbXryplslvfT4M5MBBMaek62mIbDD77pwFQHFZ5L4/wLbvaKm1VIPfe1Bs6IjqCl7A==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@opengovsg/postmangovsg-client/-/postmangovsg-client-0.0.8.tgz",
+      "integrity": "sha512-KNeoe+nl+pZEPx0cgRujSJnn5xW8AKZTbBWPv7BJZt8QNEBiEhTBcr7ZHfKfsUn8tacnDnTEmybrcgIBSoJpxg==",
       "requires": {}
     },
     "@otplib/core": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,7 +38,7 @@
     "@nestjs/serve-static": "^3.0.0",
     "@nestjs/terminus": "^9.1.4",
     "@nestjs/typeorm": "^9.0.1",
-    "@opengovsg/postmangovsg-client": "^0.0.7",
+    "@opengovsg/postmangovsg-client": "^0.0.8",
     "connect-typeorm": "^2.0.0",
     "convict": "^6.2.4",
     "dd-trace": "^3.10.0",

--- a/backend/src/config/config.schema.ts
+++ b/backend/src/config/config.schema.ts
@@ -172,10 +172,10 @@ export const schema: Schema<ConfigSchema> = {
       default: 'Starter Kit',
     },
     email: {
-      doc: 'Email to send OTP emails from. If POSTMANGOVSG_API_KEY is set, ensure that this email is the one associated with the key',
+      doc: 'Email to send OTP emails from. If POSTMANGOVSG_API_KEY is set, ensure that this email is set to `donotreply@mail.postman.gov.sg`',
       env: 'OTP_EMAIL',
       format: String,
-      default: 'donotreply@mail.open.gov.sg',
+      default: 'donotreply@mail.postman.gov.sg',
     },
   },
   postmangovsgApiKey: {


### PR DESCRIPTION
## Context

- Set `OTP_EMAIL` to a sensible default to allow Postman to smoothly send emails
- Update @opengovsg/postmangovsg-client so that sender name can be rendered into emails