### PR TITLE
fix(migrations): add `destroyedAt` column

### DIFF
--- a/backend/src/database/migrations/1659538032978-initial.ts
+++ b/backend/src/database/migrations/1659538032978-initial.ts
@@ -5,7 +5,7 @@ export class initial1659538032978 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE "sessions" ("id" character varying(255) NOT NULL, "expiredAt" bigint NOT NULL, "json" text NOT NULL DEFAULT '', CONSTRAINT "PK_3238ef96f18b355b671619111bc" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "sessions" ("id" character varying(255) NOT NULL, "expiredAt" bigint NOT NULL, "json" text NOT NULL DEFAULT '', "destroyedAt" timestamp, CONSTRAINT "PK_3238ef96f18b355b671619111bc" PRIMARY KEY ("id"))`,
     )
     await queryRunner.query(
       `CREATE INDEX "sessions_expiredAt_idx" ON "sessions" ("expiredAt") `,


### PR DESCRIPTION
## Context

The initial migration for TypeORM was missing the destroyedAt column, so add this