### PR TITLE
feat(ormconfig): replace `synchronize` with `migrationsRun`

### DIFF
--- a/backend/src/database/ormconfig.ts
+++ b/backend/src/database/ormconfig.ts
@@ -17,8 +17,9 @@ export const base = {
   database: config.get('database.name'),
   logging: config.get('database.logging'),
   // https://docs.nestjs.com/techniques/database#auto-load-entities
-  synchronize: true, // do not automatically sync entities
-  migrationsRun: false,
+  // TODO: remove migrations config and migrate schema separately
+  migrationsRun: true,
+  migrations: [join(__dirname, 'migrations', '*.{.js,.ts}')],
   // js for runtime, ts for typeorm cli
   entities: [join(__dirname, 'entities', '*.entity{.js,.ts}')],
   ...(config.get('database.ca')


### PR DESCRIPTION


## Context

TypeORM treats `synchronize` and migrations as separate processes; using one will break the other. Stick to using migrations as this is the accepted practice of rolling out database schema changes, and lean on TypeORM's first class support for migrations.

## Approach


Replace `synchronize` with config for migrations