### PR TITLE
fix: remove OTP_EMAIL to use correct Postman no-reply email

### DIFF
--- a/backend/.env.development
+++ b/backend/.env.development
@@ -4,4 +4,3 @@ DB_PASSWORD='postgres'
 DB_PORT='5432'
 DB_USERNAME='postgres'
 NODE_ENV=development
-OTP_EMAIL='donotreply@mail.open.gov.sg'

--- a/backend/.env.test
+++ b/backend/.env.test
@@ -4,4 +4,3 @@ DB_PASSWORD='postgres'
 DB_PORT='5432'
 DB_USERNAME='postgres'
 NODE_ENV=test
-OTP_EMAIL='donotreply@mail.open.gov.sg'


### PR DESCRIPTION
## Context

Default environment variable populated for `OTP_EMAIL` is wrong and will not be accepted by Postman. Currently, when the Postman API key is added, the OTP emails will still fail, with a 400 status error from Postman and a 500 error thrown by the app's backend.

## Approach

**Bug Fixes**:

- Remove the environment variable `OTP_EMAIL` so that the correct value specified in `config.schema.ts` will be loaded.