### PR TITLE
fix/otp: treat email login inputs as case-insensitive

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -47,7 +47,9 @@ export class AuthService {
   }
 
   async verifyOtp(verifyOtpDto: VerifyOtpDto): Promise<User | undefined> {
-    const { email, token } = verifyOtpDto
+    const { token } = verifyOtpDto
+    let { email } = verifyOtpDto
+    email = email.toLowerCase()
     const isVerified = this.otpService.verifyOtp(email, token)
     return isVerified
       ? await this.findOrCreate(

--- a/backend/src/otp/otp.service.ts
+++ b/backend/src/otp/otp.service.ts
@@ -18,7 +18,7 @@ export class OtpService {
   })
 
   private concatSecretWithEmail(email: string): string {
-    return this.config.get('otp.secret') + email
+    return this.config.get('otp.secret') + email.toLowerCase()
   }
 
   generateOtp(email: string): { token: string; timeLeft: number } {


### PR DESCRIPTION
## Context

Users were unable to login if they were to use upper case anywhere in their email when trying to login, and were thrown a "Incorrect OTP given" error.

## Approach

Convert email to lowercase before using it as part of the secret. 

**Improvements**:

- Since emails should be case-insensitive, the emails which users are based on should be case-insensitive as well

## Tests

Login with using emails which have upper case characters. User should be able to:
1. Key in the received OTP and login successfully
2. User should be able to access the same data regardless of what casing they typed their emails in when they logged in