### PR TITLE
refactor(auth): use `otp.sender_name` in subject

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -38,7 +38,9 @@ export class AuthService {
       from: `${this.config.get('otp.sender_name')} <${this.config.get(
         'otp.email',
       )}>`,
-      subject: `One-Time Password (OTP) for ${this.config.get('otp.sender_name')}`,
+      subject: `One-Time Password (OTP) for ${this.config.get(
+        'otp.sender_name',
+      )}`,
       html,
     }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -38,7 +38,7 @@ export class AuthService {
       from: `${this.config.get('otp.sender_name')} <${this.config.get(
         'otp.email',
       )}>`,
-      subject: 'One-Time Password (OTP) for Starter Kit',
+      subject: `One-Time Password (OTP) for ${this.config.get('otp.sender_name')}`,
       html,
     }
 


### PR DESCRIPTION
## Context and Approach
Apply DRY and use `otp.sender_name` from convict to specify both the sender and the application name in the subject