### PR TITLE
build(lint): drop custom import grouping rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['opengovsg/javascript'],
-  ignorePatterns: ['coverage', 'build', 'node_modules', 'jest.config.ts'],
+  ignorePatterns: ['coverage', 'build', 'jest.config.ts'],
   root: true,
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,28 +34,4 @@ module.exports = {
       },
     },
   ],
-  rules: {
-    // Rules for auto sort of imports
-    'simple-import-sort/imports': [
-      'error',
-      {
-        groups: [
-          // Side effect imports.
-          ['^\\u0000'],
-          // Packages.
-          // Things that start with a letter (or digit or underscore), or
-          // `@` followed by a letter.
-          ['^@?\\w'],
-          // Root imports
-          // Shared imports should be separate from application imports.
-          ['^(~shared)(/.*|$)'],
-          ['^(~)(/.*|$)'],
-          // Parent imports. Put `..` last.
-          ['^\\.\\.(?!/?$)', '^\\.\\./?$'],
-          // Other relative imports. Put same-folder imports and `.` last.
-          ['^\\./(?=.*/)(?!/?$)', '^\\.(?!/?$)', '^\\./?$'],
-        ],
-      },
-    ],
-  },
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -15,7 +15,6 @@ import { GenerateOtpDto, VerifyOtpDto } from '~shared/types/auth.dto'
 
 import { ConfigService } from '../config/config.service'
 import { UserSession } from '../types/session'
-
 import { AuthService } from './auth.service'
 
 @Controller('auth')

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -5,7 +5,6 @@ import { ConfigModule } from '../config/config.module'
 import { Session, User } from '../database/entities'
 import { MailerModule } from '../mailer/mailer.module'
 import { OtpModule } from '../otp/otp.module'
-
 import { AuthController } from './auth.controller'
 import { AuthService } from './auth.service'
 

--- a/backend/src/database/database-config.service.ts
+++ b/backend/src/database/database-config.service.ts
@@ -3,7 +3,6 @@ import { TypeOrmModuleOptions, TypeOrmOptionsFactory } from '@nestjs/typeorm'
 import { Client } from 'pg'
 
 import { ConfigService } from '../config/config.service'
-
 import { base } from './ormconfig'
 
 @Injectable()

--- a/backend/src/mailer/mailer.module.ts
+++ b/backend/src/mailer/mailer.module.ts
@@ -1,7 +1,6 @@
 import { Global, Module } from '@nestjs/common'
 
 import { ConfigModule } from '../config/config.module'
-
 import { MailerService } from './mailer.service'
 
 @Global()

--- a/backend/src/otp/otp.module.ts
+++ b/backend/src/otp/otp.module.ts
@@ -1,7 +1,6 @@
 import { Global, Module } from '@nestjs/common'
 
 import { ConfigModule } from '../config/config.module'
-
 import { OtpService } from './otp.service'
 
 @Global()

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -5,7 +5,6 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
   ],
-  ignorePatterns: ['config-overrides.js'],
   env: {
     browser: true,
     es2021: true,

--- a/frontend/config-overrides.js
+++ b/frontend/config-overrides.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-/* eslint-disable @typescript-eslint/no-var-requires */
 const { aliasWebpack, aliasJest, configPaths } = require('react-app-alias-ex')
 
 const aliasMap = configPaths('./tsconfig.paths.json')


### PR DESCRIPTION
## Context and Approach

To simplify our linting infrastructure, drop our custom import rules and enforce the default ones.
Take the chance to remove spurious ignore patterns while we are here
