### PR TITLE
refactor(validation): flatten errors in single pass

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,12 +6,6 @@ module.exports = {
     {
       files: ['*.ts', '*.tsx'],
       extends: ['opengovsg'],
-      rules: {
-        '@typescript-eslint/no-unused-vars': [
-          'error',
-          { ignoreRestSiblings: true },
-        ],
-      },
     },
   ],
 }

--- a/backend/src/core/providers/logged-validation.pipe.ts
+++ b/backend/src/core/providers/logged-validation.pipe.ts
@@ -29,17 +29,9 @@ export class LoggedValidationPipe extends ValidationPipe {
   private flattenErrors(
     errors: ValidationError[],
   ): Omit<ValidationError, 'children'>[] {
-    const children: Omit<ValidationError, 'children'>[] = errors
-      .filter((error) => error.children?.length)
-      // Filter guarantees that error.children is non-null
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      .map((error) => this.flattenErrors(error.children!))
-      .flat()
-    const result: Omit<ValidationError, 'children'>[] = errors.map((error) => {
-      const { children, ...rest } = error
-      return rest
+    const result = errors.flatMap(({ children, ...error }) => {
+      return [error].concat(this.flattenErrors(children || []))
     })
-    result.push(...children)
     return result
   }
 }


### PR DESCRIPTION
## Context

We want to enforce the no-unused-args with its defaults, but we have to rewrite the one block of code that triggers
a warning as a result

## Approach

Rewrite flatten errors to avoid non-null assertion and unused arg, with the nice side-effect of doing so in a single pass

- Rework `flattenErrors()` such that in a single pass, split each ValidationError into the error itself and its children.
  - Flat-map the two into an array containing the error, and the result from `flattenErrors(children)`
- Drop the custom options for no-unused-args, and enforce rule defaults
