### PR TITLE
build(lint): remove custom import groups

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -15,40 +15,4 @@ module.exports = {
       version: 'detect',
     },
   },
-  rules: {
-    // Rules for auto sort of imports
-    'simple-import-sort/imports': [
-      'error',
-      {
-        groups: [
-          // Side effect imports.
-          ['^\\u0000'],
-          // Packages.
-          // Packages. `react` related packages come first.
-          // Things that start with a letter (or digit or underscore), or
-          // `@` followed by a letter.
-          ['^react', '^@?\\w'],
-          // Root imports
-          // Shared imports should be separate from application imports.
-          ['^(~shared)(/.*|$)'],
-          ['^(~)(/.*|$)'],
-          [
-            '^(~lib)(/.*|$)',
-            '^(~contexts)(/.*|$)',
-            '^(~constants)(/.*|$)',
-            '^(~hooks)(/.*|$)',
-            '^(~utils)(/.*|$)',
-            '^(~services)(/.*|$)',
-            '^(~components)(/.*|$)',
-            '^(~templates)(/.*|$)',
-          ],
-          ['^(~pages)(/.*|$)', '^(~features)(/.*|$)'],
-          // Parent imports. Put `..` last.
-          ['^\\.\\.(?!/?$)', '^\\.\\./?$'],
-          // Other relative imports. Put same-folder imports and `.` last.
-          ['^\\./(?=.*/)(?!/?$)', '^\\.(?!/?$)', '^\\./?$'],
-        ],
-      },
-    ],
-  },
 }

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -5,7 +5,6 @@ import { ThemeProvider } from '@opengovsg/design-system-react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import { theme } from '~/theme'
-
 import { AuthProvider } from '~lib/auth'
 
 import { AppRouter } from './AppRouter'

--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -1,6 +1,6 @@
+import { Box } from '@chakra-ui/react'
 import { PropsWithChildren, Suspense } from 'react'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
-import { Box } from '@chakra-ui/react'
 
 import { routes } from '~constants/routes'
 import { lazyImport } from '~utils/lazyImport'

--- a/frontend/src/app/PrivateElement.tsx
+++ b/frontend/src/app/PrivateElement.tsx
@@ -1,7 +1,7 @@
 import { Navigate, NavigateProps, useLocation } from 'react-router-dom'
 
-import { useAuth } from '~lib/auth'
 import { routes } from '~constants/routes'
+import { useAuth } from '~lib/auth'
 
 interface PrivateElementProps {
   /**

--- a/frontend/src/app/PublicElement.tsx
+++ b/frontend/src/app/PublicElement.tsx
@@ -1,9 +1,9 @@
-import { Navigate, useLocation } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 import { RestrictedGovtMasthead } from '@opengovsg/design-system-react'
+import { Navigate, useLocation } from 'react-router-dom'
 
-import { useAuth } from '~lib/auth'
 import { routes } from '~constants/routes'
+import { useAuth } from '~lib/auth'
 
 interface PublicElementProps {
   /**

--- a/frontend/src/features/auth/api/fetchUser.ts
+++ b/frontend/src/features/auth/api/fetchUser.ts
@@ -1,6 +1,5 @@
-import type { WhoAmIResponseDto } from '~shared/types/auth.dto'
-
 import { api } from '~lib/api'
+import type { WhoAmIResponseDto } from '~shared/types/auth.dto'
 
 /**
  * Fetches the user from the server using the current session cookie.

--- a/frontend/src/features/auth/api/sendLoginOtp.ts
+++ b/frontend/src/features/auth/api/sendLoginOtp.ts
@@ -1,9 +1,8 @@
+import { api } from '~lib/api'
 import type {
   SendLoginOtpRequestDto,
   SendLoginOtpResponseDto,
 } from '~shared/types/auth.dto'
-
-import { api } from '~lib/api'
 
 export const sendLoginOtp = async (params: SendLoginOtpRequestDto) => {
   params.email = params.email.toLowerCase()

--- a/frontend/src/features/auth/api/verifyLoginOtp.ts
+++ b/frontend/src/features/auth/api/verifyLoginOtp.ts
@@ -1,9 +1,8 @@
+import { api } from '~lib/api'
 import {
   VerifyOtpRequestDto,
   VerifyOtpResponseDto,
 } from '~shared/types/auth.dto'
-
-import { api } from '~lib/api'
 
 export const verifyLoginOtp = async (params: VerifyOtpRequestDto) => {
   return api.url('/auth/verify').post(params).json<VerifyOtpResponseDto>()

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -1,4 +1,3 @@
-import { useForm } from 'react-hook-form'
 import { FormControl, Link, Stack } from '@chakra-ui/react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
@@ -7,11 +6,11 @@ import {
   FormLabel,
   Input,
 } from '@opengovsg/design-system-react'
+import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
-import { isGovSgEmail } from '~shared/decorators/is-gov-sg-email'
-
 import { useIsDesktop } from '~hooks/useIsDesktop'
+import { isGovSgEmail } from '~shared/decorators/is-gov-sg-email'
 
 const schema = z.object({
   email: z

--- a/frontend/src/features/auth/components/LoginImageSvgr.tsx
+++ b/frontend/src/features/auth/components/LoginImageSvgr.tsx
@@ -1,5 +1,5 @@
-import { SVGProps } from 'react'
 import { chakra } from '@chakra-ui/react'
+import { SVGProps } from 'react'
 
 export const LoginImageSvgr = chakra((props: SVGProps<SVGSVGElement>) => (
   <svg

--- a/frontend/src/features/auth/components/OtpForm.tsx
+++ b/frontend/src/features/auth/components/OtpForm.tsx
@@ -1,4 +1,3 @@
-import { useForm } from 'react-hook-form'
 import { FormControl, Stack } from '@chakra-ui/react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
@@ -7,6 +6,7 @@ import {
   FormLabel,
   Input,
 } from '@opengovsg/design-system-react'
+import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
 import { useIsDesktop } from '~hooks/useIsDesktop'

--- a/frontend/src/features/auth/components/ResendOtpButton.tsx
+++ b/frontend/src/features/auth/components/ResendOtpButton.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react'
 import { Button } from '@chakra-ui/react'
 import { useMutation } from '@tanstack/react-query'
+import { useState } from 'react'
 
 import { useInterval } from '../../../hooks/useInterval'
 

--- a/frontend/src/features/auth/routes/LoginPage.tsx
+++ b/frontend/src/features/auth/routes/LoginPage.tsx
@@ -1,10 +1,9 @@
-import { FC, PropsWithChildren, useState } from 'react'
 import { Box, Flex, GridItem, GridProps, Text } from '@chakra-ui/react'
+import { FC, PropsWithChildren, useState } from 'react'
 
 import { AppFooter } from '~/app/AppFooter'
-
-import { useAuth } from '~lib/auth'
 import { useIsDesktop } from '~hooks/useIsDesktop'
+import { useAuth } from '~lib/auth'
 import { AppGrid } from '~templates/AppGrid'
 
 import { LoginForm, LoginFormInputs } from '../components/LoginForm'

--- a/frontend/src/features/dashboard/routes/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/routes/DashboardPage.tsx
@@ -1,9 +1,9 @@
-import { Link } from 'react-router-dom'
 import { Box, ButtonGroup, Flex, HStack, Text, VStack } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
+import { Link } from 'react-router-dom'
 
-import { useAuth } from '~lib/auth'
 import { routes } from '~constants/routes'
+import { useAuth } from '~lib/auth'
 
 const Navbar = (): JSX.Element => {
   const { logout } = useAuth()

--- a/frontend/src/features/health/api/queries.ts
+++ b/frontend/src/features/health/api/queries.ts
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { HealthDto } from '~shared/types/health.dto'
-
 import { api } from '~lib/api'
+import { HealthDto } from '~shared/types/health.dto'
 
 export function useHealth() {
   const { data } = useQuery(

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -1,7 +1,5 @@
-import { createContext, ReactNode, useCallback, useContext } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-
-import { VerifyOtpRequestDto, WhoAmIResponseDto } from '~shared/types/auth.dto'
+import { createContext, ReactNode, useCallback, useContext } from 'react'
 
 import {
   fetchUser,
@@ -10,6 +8,7 @@ import {
   STORAGE_LOGGED_IN_KEY,
   verifyLoginOtp as verifyLoginOtpApi,
 } from '~features/auth'
+import { VerifyOtpRequestDto, WhoAmIResponseDto } from '~shared/types/auth.dto'
 
 import { useLocalStorage } from './storage'
 


### PR DESCRIPTION
## Context

In a bid to simplify our linting config, we need to remove as many of our own custom rules as we can

## Approach

As discussed with @karrui, remove custom import groups for frontend, and relint codebase