### PR TITLE
build(lint): reduce eslint config to single file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,11 +8,11 @@ module.exports = {
       extends: ['opengovsg'],
     },
     {
-      files: ['*.tsx'],
+      files: ['frontend/**/*.ts', '*.tsx'],
       extends: ['opengovsg', 'opengovsg/react'],
     },
     {
-      files: ['*.jsx'],
+      files: ['frontend/**/*.js', '*.jsx'],
       extends: ['opengovsg/javascript', 'opengovsg/react'],
     },
   ],

--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: ['../.eslintrc.js'],
-}

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "lint": "eslint --ext ts,tsx,js,jsx .",
-    "lint:fix": "eslint --fix --ext ts,tsx,js,jsx .",
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
     "pre-commit": "lint-staged",
     "prebuild": "rimraf build",
     "build": "nest build",

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: ['../.eslintrc.js'],
-}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,7 @@
       },
       "devDependencies": {
         "@chakra-ui/cli": "^2.3.0",
-        "@snyk/protect": "*",
+        "@snyk/protect": "latest",
         "@storybook/addon-actions": "^6.5.16",
         "@storybook/addon-essentials": "^6.5.16",
         "@storybook/addon-interactions": "^6.5.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,8 +73,8 @@
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",
-    "lint": "eslint ./ --ignore-path .gitignore",
-    "lint:fix": "eslint ./ --ignore-path .gitignore --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
     "pre-commit": "lint-staged",
     "snyk-protect": "snyk-protect",
     "prepare": "npm run snyk-protect"

--- a/shared/.eslintrc.js
+++ b/shared/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: ['../.eslintrc.js'],
-}

--- a/shared/package.json
+++ b/shared/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "pre-commit": "lint-staged",
-    "lint": "eslint --ext ts,tsx,js,jsx .",
-    "lint:fix": "eslint --fix --ext ts,tsx,js,jsx .",
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
     "build": "tsc --build --clean && tsc --build tsconfig.build.json --force",
     "test": "jest",
     "test:watch": "jest --watch --runInBand",


### PR DESCRIPTION
## Context

Reduce linting config to a bare minimum, in the name of simplification

- Harmonise lint command across all workspaces
- Configure root `.eslintrc.js` to lint frontend files, even `.ts`
- Remove workspace-specific linting config

