### PR TITLE
chore(backend): update dd-trace import location

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,3 @@
-// Initialize Datadog tracer
-import 'tracing'
-
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common'
 import { APP_PIPE } from '@nestjs/core'
 import { ServeStaticModule } from '@nestjs/serve-static'

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,3 +1,6 @@
+// Initialize Datadog tracer
+import 'tracing'
+
 import { NestFactory } from '@nestjs/core'
 import { NestExpressApplication } from '@nestjs/platform-express'
 import { ConfigService } from 'config/config.service'


### PR DESCRIPTION
## Context

Our traces currently don't have accompanied logs due to improper initialisation order as described in https://github.com/DataDog/dd-trace-js/issues/2189#issuecomment-1188455882. This PR moves importing of tracer at the start (before pino is instantiated/imported)
