### PR TITLE
docs: update github thumbprint list

### DIFF
--- a/docs/deploying/for-engineers.md
+++ b/docs/deploying/for-engineers.md
@@ -125,6 +125,7 @@ Resources:
         - sts.amazonaws.com
       ThumbprintList:
         - 6938fd4d98bab03faadb97b34396831e3780aea1
+        - 1c58a3a8518e8759bf075b76b750d4f2df264fcd
 ​
 Outputs:
   Role:


### PR DESCRIPTION
## Context

In reference to this blog post published yesterday:

https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/

It appears that the CloudFormation stack should be updated to prevent possible failures