### PR TITLE
fix: disable fallthrough so that invalid paths do not give HTTP 200

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -64,8 +64,8 @@ const FRONTEND_PATH = join(__dirname, '..', '..', 'frontend', 'build')
             res.setHeader('Cache-control', 'public, max-age=0')
           }
         },
+        fallthrough: false,
       },
-      fallthrough: false,
     }),
   ],
   providers: [

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -65,6 +65,7 @@ const FRONTEND_PATH = join(__dirname, '..', '..', 'frontend', 'build')
           }
         },
       },
+      fallthrough: false,
     }),
   ],
   providers: [


### PR DESCRIPTION
# Problem

Assume we have an API endpoint: `/items/*`.

Currently, an invalid path like:

`/item/nonsense` (note that it's `item` without `s`)

will give HTTP 200 and default HTML content instead of non HTTP 2xx.

This is wrong.

# Solution

We should disable `fallthrough` in `serveStaticOptions`. We should not let unhandled paths be "handled" by this module.

Please refer to [serveStaticOptions docs](https://github.com/nestjs/serve-static/blob/master/lib/interfaces/serve-static-options.interface.ts#L52) for more information.