### PR TITLE
fix: revert fallthrough config and fix exclude config

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -55,7 +55,10 @@ const FRONTEND_PATH = join(__dirname, '..', '..', 'frontend', 'build')
     }),
     ServeStaticModule.forRoot({
       rootPath: FRONTEND_PATH,
-      exclude: ['/api*'], // Return 404 for non-existent API routes
+      // '/api*' works for @nestjs/serve-static versions < 3.x
+      // '/api(.*)' works for @nestjs/serve-static versions >= 3.x
+      // Reference: https://github.com/nestjs/serve-static/issues/1177
+      exclude: ['/api(.*)'], // Return 404 for non-existent API routes
       serveStaticOptions: {
         maxAge: 2 * 60 * 60 * 1000, // 2 hours, same as cloudflare
         setHeaders: function (res: Response, path: string) {
@@ -64,7 +67,6 @@ const FRONTEND_PATH = join(__dirname, '..', '..', 'frontend', 'build')
             res.setHeader('Cache-control', 'public, max-age=0')
           }
         },
-        fallthrough: false,
       },
     }),
   ],


### PR DESCRIPTION
## Problem description

This is the actual fix to #3104

`exclude: ['/api*']` works for `@nestjs/serve-static` versions < 3.x
`exclude: ['/api(.*)']` works for `@nestjs/serve-static versions` >= 3.x

Reference: https://github.com/nestjs/serve-static/issues/1177

We also remove `fallthrough: false` as it was not the actual fix to #3104

## How to reproduce issue in dev:

1. In `frontend/`, run `pnpm build`
2. In `backend/`, run `pnpm dotenv -e .env.development pnpm start`
3. Visit `localhost:8080/login`
4. Refresh the page